### PR TITLE
fix(cli): align CLI test with install provider defaults

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -216,14 +216,11 @@ describe("CLI installer", () => {
         "https://portal.qwen.ai/v1",
       );
       expect(config.provider.qwen.options.compatibility).toBe("strict");
-      expect(config.provider.qwen.models["qwen3-coder-plus"]).toBeDefined();
-      expect(
-        config.provider.qwen.models["qwen3-coder-plus"].contextWindow,
-      ).toBe(1048576);
-      expect(config.provider.qwen.models["qwen3-vl-plus"]).toBeDefined();
-      expect(config.provider.qwen.models["qwen3-vl-plus"].attachment).toBe(
-        true,
+      expect(config.provider.qwen.models["coder-model"]).toBeDefined();
+      expect(config.provider.qwen.models["coder-model"].limit.context).toBe(
+        1048576,
       );
+      expect(config.provider.qwen.models["coder-model"].attachment).toBe(true);
     });
 
     it("should complete without prompting when skipPrompt is true", async () => {


### PR DESCRIPTION
Updates the CLI installer test to match `DEFAULT_PROVIDER_CONFIG` in `install.ts` (coder-model schema). Restores a green test suite so CI and npm release workflows can run.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the CLI installer test with `DEFAULT_PROVIDER_CONFIG` in `install.ts`, asserting the `qwen` provider seeds `coder-model` with `limit.context = 1048576` and `attachment = true`. Restores passing tests so CI and npm release workflows can run.

<sup>Written for commit 07f0478d90b2073bb42a6313277c096b935367e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

