### PR TITLE
ci(release): upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 
+      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1 (see npm trusted-publishers docs).
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@">=11.5.1" && npm --version
+
       - name: Determine npm tag
         id: npm-tag
         run: |


### PR DESCRIPTION
npm trusted publishing requires CLI `>= 11.5.1`. Node 24’s bundled npm may be older; install a current npm before `npm publish` so OIDC authentication works.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `npm` to >=11.5.1 in the release workflow to enable OIDC trusted publishing. Prevents auth errors when Node 24’s bundled `npm` is older during `npm publish`.

<sup>Written for commit 99e95ad2c4f954d0be73b4e1466eebfc638384bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

