### PR TITLE
chore: bump version to 0.0.2 for npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-qwencode-oauth",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Qwen OAuth authentication plugin for OpenCode with multi-account rotation and API translation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumps the package version so we can publish a new GitHub release and run the Release workflow with the npm \u003e= 11.5.1 OIDC fix merged in #3. v0.0.1\u2019s workflow run used the older workflow definition.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `opencode-qwencode-oauth` to 0.0.2 to trigger a new release run with the npm >= 11.5.1 OIDC fix. This replaces the v0.0.1 run that used the older workflow.

<sup>Written for commit c7e80eb87cc91a21e1b33c7b5067345d52edb5dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

