### PR TITLE
ci(release): fix npm OIDC vs token auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,11 @@ jobs:
       - name: Build
         run: bun run build
 
+      # Do not set registry-url here: it injects NODE_AUTH_TOKEN from the GitHub token, which is
+      # invalid for registry.npmjs.org and blocks OIDC trusted publishing (npm >= 11.5.1).
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
 
       # Trusted publishing (OIDC) requires npm CLI >= 11.5.1 (see npm trusted-publishers docs).
       - name: Upgrade npm for OIDC trusted publishing
@@ -43,5 +44,16 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Publish to npm
+      # OIDC: no NODE_AUTH_TOKEN (add Trusted Publisher for this package on npmjs.com).
+      # Fallback: add repo secret NPM_TOKEN (granular publish) until OIDC is configured.
+      - name: Publish to npm (OIDC trusted publishing)
+        if: ${{ secrets.NPM_TOKEN == '' }}
         run: npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
+
+      - name: Publish to npm (NPM_TOKEN secret)
+        if: ${{ secrets.NPM_TOKEN != '' }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes `registry-url` from setup-node so the GitHub token is not sent to registry.npmjs.org (that blocked OIDC).\n\n- **OIDC path** (no `NPM_TOKEN` secret): configure [Trusted Publisher](https://docs.npmjs.com/trusted-publishers) for `opencode-qwencode-oauth` → GitHub `mseptiaan/opencode-qwencode-oauth`, workflow `release.yml`.\n- **Token path**: add repo secret `NPM_TOKEN` (granular publish) to publish without OIDC setup.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release npm auth by removing `registry-url` from `actions/setup-node@v4`, enabling OIDC trusted publishing to `registry.npmjs.org`. Adds a fallback to publish with `NPM_TOKEN` if OIDC isn’t configured.

- **Bug Fixes**
  - Remove `registry-url` so `GITHUB_TOKEN` isn’t injected as `NODE_AUTH_TOKEN`, unblocking OIDC; upgrade `npm` to >= 11.5.1 before publish.
  - Conditional publish: OIDC when `NPM_TOKEN` is absent; token-based publish when `NPM_TOKEN` is set.

- **Migration**
  - Preferred: set up npm Trusted Publisher for the package (link to this repo and `release.yml`) and omit `NPM_TOKEN`.
  - Temporary: add repo secret `NPM_TOKEN` (publish scope) to use the token path.

<sup>Written for commit 9775404bcd93e7a8a251091ffd9c4f4418db906c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

