### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-qwencode-oauth",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Qwen OAuth authentication plugin for OpenCode with multi-account rotation and API translation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Triggers the Release workflow with the npm auth fix from #5.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `opencode-qwencode-oauth` to 0.0.3 to trigger a new release that includes the npm auth fix from #5.

<sup>Written for commit eea161ea13f788c0142ffa377a79368a0583e896. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

