### PR TITLE
fix: release workflow + npm bin + local publish scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,16 +44,14 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
-      # OIDC: no NODE_AUTH_TOKEN (add Trusted Publisher for this package on npmjs.com).
-      # Fallback: add repo secret NPM_TOKEN (granular publish) until OIDC is configured.
-      - name: Publish to npm (OIDC trusted publishing)
-        if: ${{ secrets.NPM_TOKEN == '' }}
-        run: npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
-
-      - name: Publish to npm (NPM_TOKEN secret)
-        if: ${{ secrets.NPM_TOKEN != '' }}
+      # OIDC: do not set npm registry auth (configure Trusted Publisher on npm for this package).
+      # Token: set repo secret NPM_TOKEN (granular publish) — shell only applies it when non-empty.
+      # (GitHub forbids `secrets` in `if:` — that invalidates the workflow.)
+      - name: Publish to npm
         run: |
-          npm config set //registry.npmjs.org/:_authToken "${NODE_AUTH_TOKEN}"
+          if [ -n "${NPM_TOKEN:-}" ]; then
+            npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
+          fi
           npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "bin": {
-    "opencode-qwencode-oauth": "./dist/src/cli/install.js"
+    "opencode-qwencode-oauth": "dist/src/cli/install.js"
   },
   "type": "module",
   "license": "Apache-2.0",
@@ -61,7 +61,9 @@
     "test:coverage": "bun test --coverage",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "bun run build",
+    "publish:local": "npm publish --access public",
+    "publish:dry-run": "npm publish --dry-run --access public"
   },
   "peerDependencies": {
     "@opencode-ai/plugin": "^1.0.150",


### PR DESCRIPTION
- Removes invalid `secrets` usage in `if:` (GitHub rejects the workflow).\n- Uses shell to apply `NPM_TOKEN` when set; otherwise OIDC for `npm publish`.\n- `npm pkg fix` bin path; add `publish:local` / `publish:dry-run`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the npm release workflow and CLI bin path, and adds local publish scripts for easier testing.

- **Bug Fixes**
  - Replaces invalid `if: secrets.*` checks with shell-based `NPM_TOKEN` handling; falls back to OIDC for `npm publish`.
  - Corrects `bin` path to `dist/src/cli/install.js` (no leading `./`).

- **New Features**
  - Adds `publish:local` and `publish:dry-run` npm scripts.

<sup>Written for commit 40ce93b748f0e82872ed2dbd65a75551c881e387. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

