### PR TITLE
chore: bump version to 1.0.1 and update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,25 @@
-name: Release
+name: Publish Package
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
+  id-token: write # Required for OIDC
   contents: read
-  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v6
         with:
-          bun-version: "latest"
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build
-        run: bun run build
-
-      # Do not set registry-url here: it injects NODE_AUTH_TOKEN from the GitHub token, which is
-      # invalid for registry.npmjs.org and blocks OIDC trusted publishing (npm >= 11.5.1).
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-
-      # Trusted publishing (OIDC) requires npm CLI >= 11.5.1 (see npm trusted-publishers docs).
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@">=11.5.1" && npm --version
-
-      - name: Determine npm tag
-        id: npm-tag
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          if [[ "$VERSION" == *"-"* ]]; then
-            echo "tag=beta" >> $GITHUB_OUTPUT
-          else
-            echo "tag=latest" >> $GITHUB_OUTPUT
-          fi
-
-      # OIDC: do not set npm registry auth (configure Trusted Publisher on npm for this package).
-      # Token: set repo secret NPM_TOKEN (granular publish) — shell only applies it when non-empty.
-      # (GitHub forbids `secrets` in `if:` — that invalidates the workflow.)
-      - name: Publish to npm
-        run: |
-          if [ -n "${NPM_TOKEN:-}" ]; then
-            npm config set //registry.npmjs.org/:_authToken "${NPM_TOKEN}"
-          fi
-          npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-qwencode-oauth",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Qwen OAuth authentication plugin for OpenCode with multi-account rotation and API translation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Updated package version from 1.0.0 to 1.0.1 in package.json.
- Changed GitHub Actions workflow to trigger on tag pushes instead of releases.
- Updated actions versions for improved compatibility and performance.
- Streamlined the npm publish process by removing deprecated steps.

## Summary
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [X] 🔧 Config/CI

## Self-Review Checklist
- [ ] Code compiles and tests pass (`bun test`)
- [ ] Lint passes (`bun run lint`)
- [ ] Build succeeds (`bun run build`)
- [ ] Changes are covered by tests (if applicable)
- [ ] README/AGENTS.md updated (if applicable)
- [ ] No hardcoded secrets or credentials
- [ ] Commit messages are clear and descriptive

## Related Issues
<!-- Use "Closes #123" to auto-close issues -->
Closes #


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps package version to 1.0.1 and simplifies the release workflow for npm publishing.

- **Refactors**
  - Workflow now runs on version tag pushes (`v*`) instead of GitHub Releases.
  - Switch from `oven-sh/setup-bun` to `actions/setup-node@v6` (Node 24) and run `npm ci` → build → test → `npm publish`.
  - Upgrade to `actions/checkout@v6` and remove deprecated/trusted-publishing steps; set npm `registry-url` for publishing.

<sup>Written for commit 590ec125fd081f2c0104e633f8201f3f1d2ca00b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

