### PR TITLE
fix: make OAuth auth detection more lenient for desktop mode

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -296,7 +296,17 @@ export const createQwenOAuthPlugin =
         provider: providerId,
         async loader(getAuth: GetAuth, provider: Provider) {
           const auth = (await getAuth()) as AuthDetails;
+          logger.debug("Auth loader called", {
+            hasType: "type" in auth,
+            authType: auth.type,
+            hasRefresh: typeof auth.refresh === "string",
+            refreshLength:
+              typeof auth.refresh === "string" ? auth.refresh.length : 0,
+          });
           if (!isOAuthAuth(auth)) {
+            logger.debug(
+              "Auth not recognized as OAuth, returning empty object",
+            );
             return {};
           }
 

--- a/src/plugin/auth.ts
+++ b/src/plugin/auth.ts
@@ -1,11 +1,13 @@
 import type { AuthDetails, OAuthAuthDetails } from "./types";
 
 export function isOAuthAuth(auth: AuthDetails): auth is OAuthAuthDetails {
-  return (
-    auth.type === "oauth" &&
-    typeof auth.refresh === "string" &&
-    auth.refresh.length > 0
-  );
+  if (auth.type === "oauth") {
+    return typeof auth.refresh === "string" && auth.refresh.length > 0;
+  }
+  if (typeof auth.refresh === "string" && auth.refresh.length > 0) {
+    return true;
+  }
+  return false;
 }
 
 export function calculateTokenExpiry(


### PR DESCRIPTION
## Summary
- Fixes #12: Plugin works in TUI but returns 404 in desktop mode
- Made `isOAuthAuth` function more lenient to accept auth objects with valid refresh tokens even if `type: "oauth"` is not explicitly set
- Added debug logging to auth loader to help diagnose auth issues

## Problem
The plugin was working in TUI mode but failing in desktop mode with a 404 error on `/v1/responses`. The root cause was that the auth loader was returning an empty object `{}` when the stored auth didn't have `type: "oauth"` explicitly set, which could happen if OpenCode's desktop mode stores OAuth credentials differently.

## Solution
Modified `isOAuthAuth` to accept any auth object with a valid `refresh` token, regardless of whether `type` is set to "oauth". This ensures the custom fetch function is always provided when valid OAuth credentials exist.

## Testing
- All 135 existing tests pass
- Lint and typecheck pass
- Build succeeds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth auth detection more lenient so desktop mode recognizes valid credentials and stops returning 404s on `/v1/responses`. Also adds debug logs to help diagnose auth loading.

- **Bug Fixes**
  - `isOAuthAuth` now treats any auth with a non-empty `refresh` token as OAuth, even if `type` is missing.
  - Added debug logging in the auth loader to report `type` presence and `refresh` token status.

<sup>Written for commit 2cbc66c3981c18661d83a6632a0e1bfadbe6f4bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

