### PR TITLE
feat: implement account deletion and enhance token validation

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -220,6 +220,23 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function deleteAccount(storage: AccountStorage, index: number): AccountStorage {
+  if (index < 0 || index >= storage.accounts.length) {
+    return storage;
+  }
+  const accounts = storage.accounts.filter((_, i) => i !== index);
+  if (accounts.length === 0) {
+    return { version: 1, accounts: [], activeIndex: 0 };
+  }
+  let activeIndex = storage.activeIndex;
+  if (index < activeIndex) {
+    activeIndex -= 1;
+  } else if (index === activeIndex) {
+    activeIndex = Math.min(activeIndex, accounts.length - 1);
+  }
+  return { version: 1, accounts, activeIndex };
+}
+
 async function ensureAuthInStorage(
   storage: AccountStorage | null,
   auth: OAuthAuthDetails,
@@ -242,22 +259,22 @@ function initializeTrackers(config: LoadedConfig): void {
   initHealthTracker(
     config.health_score
       ? {
-          initial: config.health_score.initial,
-          successReward: config.health_score.success_reward,
-          rateLimitPenalty: config.health_score.rate_limit_penalty,
-          failurePenalty: config.health_score.failure_penalty,
-          recoveryRatePerHour: config.health_score.recovery_rate_per_hour,
-          minUsable: config.health_score.min_usable,
-        }
+        initial: config.health_score.initial,
+        successReward: config.health_score.success_reward,
+        rateLimitPenalty: config.health_score.rate_limit_penalty,
+        failurePenalty: config.health_score.failure_penalty,
+        recoveryRatePerHour: config.health_score.recovery_rate_per_hour,
+        minUsable: config.health_score.min_usable,
+      }
       : undefined,
   );
   initTokenTracker(
     config.token_bucket
       ? {
-          maxTokens: config.token_bucket.max_tokens,
-          regenerationRatePerMinute:
-            config.token_bucket.regeneration_rate_per_minute,
-        }
+        maxTokens: config.token_bucket.max_tokens,
+        regenerationRatePerMinute:
+          config.token_bucket.regeneration_rate_per_minute,
+      }
       : undefined,
   );
 }
@@ -269,402 +286,422 @@ function getPidOffset(config: LoadedConfig): number {
 
 export const createQwenOAuthPlugin =
   (providerId: string): Plugin =>
-  async ({ client, directory }: PluginContext) => {
-    const config = loadConfig(directory);
-    setLoggerQuietMode(config.quiet_mode);
-    initDebugFromEnv();
-    initializeTrackers(config);
-    const existingStorage = await loadAccounts();
-    await loadTrackerState(
-      getHealthTracker(),
-      getTokenTracker(),
-      existingStorage?.accounts,
-    );
+    async ({ client, directory }: PluginContext) => {
+      const config = loadConfig(directory);
+      setLoggerQuietMode(config.quiet_mode);
+      initDebugFromEnv();
+      initializeTrackers(config);
+      const existingStorage = await loadAccounts();
+      await loadTrackerState(
+        getHealthTracker(),
+        getTokenTracker(),
+        existingStorage?.accounts,
+      );
 
-    const pidOffset = getPidOffset(config);
-    logger.debug("Plugin initialized", {
-      providerId,
-      directory,
-      strategy: config.rotation_strategy,
-      pidOffset: config.pid_offset_enabled ? pidOffset : "disabled",
-    });
+      const pidOffset = getPidOffset(config);
+      logger.debug("Plugin initialized", {
+        providerId,
+        directory,
+        strategy: config.rotation_strategy,
+        pidOffset: config.pid_offset_enabled ? pidOffset : "disabled",
+      });
 
-    const oauthOptions = buildOAuthOptions(config);
+      const oauthOptions = buildOAuthOptions(config);
 
-    return {
-      auth: {
-        provider: providerId,
-        async loader(getAuth: GetAuth, provider: Provider) {
-          const auth = (await getAuth()) as AuthDetails;
-          if (!isOAuthAuth(auth)) {
-            return {};
-          }
+      return {
+        auth: {
+          provider: providerId,
+          async loader(getAuth: GetAuth, provider: Provider) {
+            const auth = (await getAuth()) as AuthDetails;
+            if (!isOAuthAuth(auth)) {
+              return {};
+            }
 
-          let accountStorage = await ensureAuthInStorage(
-            existingStorage ?? (await loadAccounts()),
-            auth,
-          );
+            let accountStorage = await ensureAuthInStorage(
+              existingStorage ?? (await loadAccounts()),
+              auth,
+            );
 
-          if (provider.models) {
-            for (const model of Object.values(provider.models)) {
-              if (model) {
-                model.cost = {
-                  input: 0,
-                  output: 0,
-                  cache: { read: 0, write: 0 },
-                };
+            if (provider.models) {
+              for (const model of Object.values(provider.models)) {
+                if (model) {
+                  model.cost = {
+                    input: 0,
+                    output: 0,
+                    cache: { read: 0, write: 0 },
+                  };
+                }
               }
             }
-          }
 
-          return {
-            apiKey: "",
-            fetch: async (
-              input: RequestInfo | URL,
-              init?: RequestInit,
-            ): Promise<Response> => {
-              let attempts = 0;
-              const healthTracker = getHealthTracker();
-              const tokenTracker = getTokenTracker();
-              const selectOptions: SelectAccountOptions = {
-                healthTracker,
-                tokenTracker,
-                pidOffset,
-              };
-
-              while (true) {
-                const now = Date.now();
-                const selection = selectAccount(
-                  accountStorage,
-                  config.rotation_strategy,
-                  now,
-                  selectOptions,
-                );
-
-                if (!selection) {
-                  const waitMs = getMinRateLimitWait(accountStorage, now);
-                  if (!waitMs) {
-                    throw new Error(
-                      "No available Qwen OAuth accounts. Re-authenticate to continue.",
-                    );
-                  }
-
-                  const maxWaitMs =
-                    (config.max_rate_limit_wait_seconds ?? 0) * 1000;
-                  if (maxWaitMs > 0 && waitMs > maxWaitMs) {
-                    throw new Error(
-                      "All Qwen OAuth accounts are rate-limited. Try again later.",
-                    );
-                  }
-
-                  await sleep(waitMs);
-                  continue;
-                }
-
-                accountStorage = selection.storage;
-                const account = selection.account;
-                const accountIndex = selection.index;
-
-                let activeAuth: OAuthAuthDetails = {
-                  type: "oauth",
-                  refresh: account.refreshToken,
-                  access: account.accessToken,
-                  expires: account.expires,
-                  resourceUrl: account.resourceUrl,
+            return {
+              apiKey: "",
+              fetch: async (
+                input: RequestInfo | URL,
+                init?: RequestInit,
+              ): Promise<Response> => {
+                let attempts = 0;
+                const healthTracker = getHealthTracker();
+                const tokenTracker = getTokenTracker();
+                const selectOptions: SelectAccountOptions = {
+                  healthTracker,
+                  tokenTracker,
+                  pidOffset,
                 };
 
-                const refreshBuffer = config.proactive_refresh
-                  ? config.refresh_window_seconds
-                  : 0;
-                if (
-                  !activeAuth.access ||
-                  accessTokenExpired(activeAuth, refreshBuffer)
-                ) {
-                  logger.debug("Token refresh needed", {
-                    accountIndex,
-                    hasAccess: !!activeAuth.access,
-                    proactive: config.proactive_refresh,
-                  });
-                  try {
-                    const refreshed = await refreshAccessToken(
-                      activeAuth,
-                      oauthOptions,
-                      client,
-                      providerId,
-                    );
-                    if (!refreshed) {
-                      throw new Error("Token refresh failed");
-                    }
-                    logger.debug("Token refreshed successfully", {
-                      accountIndex,
-                    });
-                    activeAuth = {
-                      type: "oauth",
-                      refresh: refreshed.refresh,
-                      access: refreshed.access,
-                      expires: refreshed.expires,
-                      resourceUrl: refreshed.resourceUrl ?? account.resourceUrl,
-                    };
-                    accountStorage = updateAccount(
-                      accountStorage,
-                      accountIndex,
-                      {
-                        refreshToken: refreshed.refresh,
-                        accessToken: refreshed.access,
-                        expires: refreshed.expires,
-                        resourceUrl:
-                          refreshed.resourceUrl ?? account.resourceUrl,
-                        lastUsed: now,
-                      },
-                    );
-                    await saveAccounts(accountStorage);
-                  } catch (error) {
-                    const refreshError = error as QwenTokenRefreshError;
-                    logger.debug("Token refresh failed", {
-                      accountIndex,
-                      code: refreshError.code,
-                    });
-                    if (refreshError.code === "invalid_grant") {
-                      logger.debug(
-                        "Refresh token revoked for account, marking as requiresReauth",
-                        { accountIndex },
+                while (true) {
+                  const now = Date.now();
+                  const selection = selectAccount(
+                    accountStorage,
+                    config.rotation_strategy,
+                    now,
+                    selectOptions,
+                  );
+
+                  if (!selection) {
+                    const waitMs = getMinRateLimitWait(accountStorage, now);
+                    if (!waitMs) {
+                      throw new Error(
+                        "No available Qwen OAuth accounts. Re-authenticate to continue.",
                       );
+                    }
+
+                    const maxWaitMs =
+                      (config.max_rate_limit_wait_seconds ?? 0) * 1000;
+                    if (maxWaitMs > 0 && waitMs > maxWaitMs) {
+                      throw new Error(
+                        "All Qwen OAuth accounts are rate-limited. Try again later.",
+                      );
+                    }
+
+                    await sleep(waitMs);
+                    continue;
+                  }
+
+                  accountStorage = selection.storage;
+                  const account = selection.account;
+                  const accountIndex = selection.index;
+
+                  let activeAuth: OAuthAuthDetails = {
+                    type: "oauth",
+                    refresh: account.refreshToken,
+                    access: account.accessToken,
+                    expires: account.expires,
+                    resourceUrl: account.resourceUrl,
+                  };
+
+                  const refreshBuffer = config.proactive_refresh
+                    ? config.refresh_window_seconds
+                    : 0;
+                  if (
+                    !activeAuth.access ||
+                    accessTokenExpired(activeAuth, refreshBuffer)
+                  ) {
+                    logger.debug("Token refresh needed", {
+                      accountIndex,
+                      hasAccess: !!activeAuth.access,
+                      proactive: config.proactive_refresh,
+                    });
+                    try {
+                      logger.debug("Refreshing token", {
+                        activeAuth,
+                        oauthOptions,
+                        client,
+                        providerId,
+                      });
+                      const refreshed = await refreshAccessToken(
+                        activeAuth,
+                        oauthOptions,
+                        client,
+                        providerId,
+                      );
+                      if (!refreshed) {
+                        throw new Error("Token refresh failed");
+                      }
+                      logger.debug("Token refreshed successfully", {
+                        accountIndex,
+                      });
+                      activeAuth = {
+                        type: "oauth",
+                        refresh: refreshed.refresh,
+                        access: refreshed.access,
+                        expires: refreshed.expires,
+                        resourceUrl: refreshed.resourceUrl ?? account.resourceUrl,
+                      };
                       accountStorage = updateAccount(
                         accountStorage,
                         accountIndex,
                         {
-                          requiresReauth: true,
-                          accessToken: undefined,
-                          expires: undefined,
+                          refreshToken: refreshed.refresh,
+                          accessToken: refreshed.access,
+                          expires: refreshed.expires,
+                          resourceUrl:
+                            refreshed.resourceUrl ?? account.resourceUrl,
+                          lastUsed: now,
                         },
                       );
                       await saveAccounts(accountStorage);
-                    } else {
-                      tokenTracker.refund(accountIndex);
+                    } catch (error) {
+                      const refreshError = error as QwenTokenRefreshError;
+                      logger.debug("Token refresh failed", {
+                        accountIndex,
+                        code: refreshError.code,
+                      });
+                      if (refreshError.code === "invalid_grant") {
+                        logger.debug(
+                          "Refresh token revoked for account, marking as requiresReauth",
+                          { accountIndex },
+                        );
+                        accountStorage = updateAccount(
+                          accountStorage,
+                          accountIndex,
+                          {
+                            requiresReauth: true,
+                            accessToken: undefined,
+                            expires: undefined,
+                          },
+                        );
+                        await saveAccounts(accountStorage);
+                        attempts += 1;
+                        if (attempts >= accountStorage.accounts.length) {
+                          throw error;
+                        }
+                        continue;
+                      }
+                      logger.debug("Removing account after refresh failure", {
+                        accountIndex,
+                        code: refreshError.code,
+                      });
+                      accountStorage = deleteAccount(
+                        accountStorage,
+                        accountIndex,
+                      );
+                      await saveAccounts(accountStorage);
+                      healthTracker.removeAccountAt(accountIndex);
+                      tokenTracker.removeAccountAt(accountIndex);
+                      await saveTrackerState(healthTracker, tokenTracker);
+                      if (accountStorage.accounts.length === 0) {
+                        throw error;
+                      }
+                      continue;
                     }
-                    attempts += 1;
-                    if (attempts >= accountStorage.accounts.length) {
-                      throw error;
-                    }
-                    continue;
                   }
-                }
 
-                // Get URL from input - OpenCode already constructs full URLs
-                let rawUrl: string;
-                if (typeof input === "string") {
-                  rawUrl = input;
-                } else if (input instanceof URL) {
-                  rawUrl = input.toString();
-                } else {
-                  rawUrl = input.url;
-                }
+                  // Get URL from input - OpenCode already constructs full URLs
+                  let rawUrl: string;
+                  if (typeof input === "string") {
+                    rawUrl = input;
+                  } else if (input instanceof URL) {
+                    rawUrl = input.toString();
+                  } else {
+                    rawUrl = input.url;
+                  }
 
-                // Sanitize malformed URLs (e.g., "undefined/path")
-                rawUrl = sanitizeMalformedUrl(rawUrl);
+                  // Sanitize malformed URLs (e.g., "undefined/path")
+                  rawUrl = sanitizeMalformedUrl(rawUrl);
 
-                let requestInit =
-                  init ??
-                  (input instanceof Request
-                    ? {
+                  let requestInit =
+                    init ??
+                    (input instanceof Request
+                      ? {
                         method: input.method,
                         headers: input.headers,
                         body: input.body,
                         signal: input.signal,
                       }
-                    : undefined);
+                      : undefined);
 
-                if (!requestInit && !(input instanceof Request)) {
-                  requestInit = {};
-                }
+                  if (!requestInit && !(input instanceof Request)) {
+                    requestInit = {};
+                  }
 
-                const needsResponsesTransform = rawUrl.endsWith("/responses");
-                const finalUrl = rawUrl.replace(
-                  /\/responses$/,
-                  "/chat/completions",
-                );
+                  const needsResponsesTransform = rawUrl.endsWith("/responses");
+                  const finalUrl = rawUrl.replace(
+                    /\/responses$/,
+                    "/chat/completions",
+                  );
 
-                const finalInit = { ...requestInit };
-                if (needsResponsesTransform && requestInit?.body) {
-                  try {
-                    const bodyStr =
-                      typeof requestInit.body === "string"
-                        ? requestInit.body
-                        : await new Response(requestInit.body).text();
-                    const body = JSON.parse(bodyStr);
-                    const transformed =
-                      transformResponsesToChatCompletions(body);
-                    finalInit.body = JSON.stringify(transformed);
-                    logger.verbose("Transformed request body", {
-                      messagesCount: transformed.messages?.length,
-                      hasTools: !!transformed.tools,
+                  const finalInit = { ...requestInit };
+                  if (needsResponsesTransform && requestInit?.body) {
+                    try {
+                      const bodyStr =
+                        typeof requestInit.body === "string"
+                          ? requestInit.body
+                          : await new Response(requestInit.body).text();
+                      const body = JSON.parse(bodyStr);
+                      const transformed =
+                        transformResponsesToChatCompletions(body);
+                      finalInit.body = JSON.stringify(transformed);
+                      logger.verbose("Transformed request body", {
+                        messagesCount: transformed.messages?.length,
+                        hasTools: !!transformed.tools,
+                      });
+                    } catch {
+                      logger.debug("Body parse failed, using original");
+                    }
+                  }
+
+                  const headers = transformHeader(requestInit?.headers, {
+                    accessToken: activeAuth.access,
+                    forceJsonContentType: needsResponsesTransform,
+                  });
+
+                  logger.debug("Sending request", {
+                    url: finalUrl,
+                    method: finalInit.method ?? "POST",
+                    needsTransform: needsResponsesTransform,
+                  });
+
+                  const response = await fetch(finalUrl, {
+                    ...finalInit,
+                    headers,
+                  });
+
+                  logger.debug("Response received", {
+                    status: response.status,
+                    contentType: response.headers.get("content-type"),
+                  });
+
+                  // Transform streaming response from Chat Completions to Responses API format
+                  if (
+                    needsResponsesTransform &&
+                    response.ok &&
+                    response.body &&
+                    response.headers
+                      .get("content-type")
+                      ?.includes("text/event-stream")
+                  ) {
+                    const sseCtx = createSSETransformContext(logger);
+                    const transformStream = createSSETransformStream(sseCtx);
+                    const transformedBody =
+                      response.body.pipeThrough(transformStream);
+                    return new Response(transformedBody, {
+                      status: response.status,
+                      statusText: response.statusText,
+                      headers: response.headers,
                     });
-                  } catch {
-                    logger.debug("Body parse failed, using original");
                   }
-                }
 
-                const headers = transformHeader(requestInit?.headers, {
-                  accessToken: activeAuth.access,
-                  forceJsonContentType: needsResponsesTransform,
-                });
+                  if (
+                    needsResponsesTransform &&
+                    response.ok &&
+                    !response.headers
+                      .get("content-type")
+                      ?.includes("text/event-stream")
+                  ) {
+                    logger.debug("Transforming non-streaming response");
+                    const chatBody = await response.json();
+                    const ctx = createTransformContext();
+                    const responsesBody = transformChatCompletionsToResponses(
+                      chatBody,
+                      ctx,
+                    );
 
-                logger.debug("Sending request", {
-                  url: finalUrl,
-                  method: finalInit.method ?? "POST",
-                  needsTransform: needsResponsesTransform,
-                });
-
-                const response = await fetch(finalUrl, {
-                  ...finalInit,
-                  headers,
-                });
-
-                logger.debug("Response received", {
-                  status: response.status,
-                  contentType: response.headers.get("content-type"),
-                });
-
-                // Transform streaming response from Chat Completions to Responses API format
-                if (
-                  needsResponsesTransform &&
-                  response.ok &&
-                  response.body &&
-                  response.headers
-                    .get("content-type")
-                    ?.includes("text/event-stream")
-                ) {
-                  const sseCtx = createSSETransformContext(logger);
-                  const transformStream = createSSETransformStream(sseCtx);
-                  const transformedBody =
-                    response.body.pipeThrough(transformStream);
-                  return new Response(transformedBody, {
-                    status: response.status,
-                    statusText: response.statusText,
-                    headers: response.headers,
-                  });
-                }
-
-                if (
-                  needsResponsesTransform &&
-                  response.ok &&
-                  !response.headers
-                    .get("content-type")
-                    ?.includes("text/event-stream")
-                ) {
-                  logger.debug("Transforming non-streaming response");
-                  const chatBody = await response.json();
-                  const ctx = createTransformContext();
-                  const responsesBody = transformChatCompletionsToResponses(
-                    chatBody,
-                    ctx,
-                  );
-
-                  return new Response(JSON.stringify(responsesBody), {
-                    status: response.status,
-                    statusText: response.statusText,
-                    headers: new Headers({
-                      "content-type": "application/json",
-                    }),
-                  });
-                }
-
-                if (response.status === 429 || response.status >= 500) {
-                  const reason = parseRateLimitReason(response);
-                  const headerMs = extractRetryAfterMs(response);
-                  const tieredMs = getBackoffMs(reason, attempts);
-                  const retryAfterMs = headerMs ?? tieredMs;
-
-                  logger.debug("Rate limited or server error", {
-                    status: response.status,
-                    reason,
-                    accountIndex,
-                    retryAfterMs,
-                    attempts,
-                    totalAccounts: accountStorage.accounts.length,
-                  });
-
-                  accountStorage = markRateLimited(
-                    accountStorage,
-                    accountIndex,
-                    retryAfterMs,
-                  );
-                  accountStorage = recordFailure(accountStorage, accountIndex);
-                  if (response.status === 429) {
-                    healthTracker.recordRateLimit(accountIndex);
-                  } else {
-                    healthTracker.recordFailure(accountIndex);
+                    return new Response(JSON.stringify(responsesBody), {
+                      status: response.status,
+                      statusText: response.statusText,
+                      headers: new Headers({
+                        "content-type": "application/json",
+                      }),
+                    });
                   }
+
+                  if (response.status === 429 || response.status >= 500) {
+                    const reason = parseRateLimitReason(response);
+                    const headerMs = extractRetryAfterMs(response);
+                    const tieredMs = getBackoffMs(reason, attempts);
+                    const retryAfterMs = headerMs ?? tieredMs;
+
+                    logger.debug("Rate limited or server error", {
+                      status: response.status,
+                      reason,
+                      accountIndex,
+                      retryAfterMs,
+                      attempts,
+                      totalAccounts: accountStorage.accounts.length,
+                    });
+
+                    accountStorage = markRateLimited(
+                      accountStorage,
+                      accountIndex,
+                      retryAfterMs,
+                    );
+                    accountStorage = recordFailure(accountStorage, accountIndex);
+                    if (response.status === 429) {
+                      healthTracker.recordRateLimit(accountIndex);
+                    } else {
+                      healthTracker.recordFailure(accountIndex);
+                    }
+                    await saveAccounts(accountStorage);
+                    await saveTrackerState(healthTracker, tokenTracker);
+                    attempts += 1;
+                    if (attempts >= accountStorage.accounts.length) {
+                      const waitMs = getMinRateLimitWait(
+                        accountStorage,
+                        Date.now(),
+                      );
+                      if (waitMs) {
+                        logger.debug("All accounts rate limited, waiting", {
+                          waitMs,
+                        });
+                        await sleep(waitMs);
+                        attempts = 0;
+                        continue;
+                      }
+                      return response;
+                    }
+                    continue;
+                  }
+
+                  accountStorage = recordSuccess(accountStorage, accountIndex);
+                  healthTracker.recordSuccess(accountIndex);
                   await saveAccounts(accountStorage);
                   await saveTrackerState(healthTracker, tokenTracker);
-                  attempts += 1;
-                  if (attempts >= accountStorage.accounts.length) {
-                    const waitMs = getMinRateLimitWait(
-                      accountStorage,
-                      Date.now(),
-                    );
-                    if (waitMs) {
-                      logger.debug("All accounts rate limited, waiting", {
-                        waitMs,
-                      });
-                      await sleep(waitMs);
-                      attempts = 0;
-                      continue;
-                    }
-                    return response;
-                  }
-                  continue;
+                  return response;
                 }
-
-                accountStorage = recordSuccess(accountStorage, accountIndex);
-                healthTracker.recordSuccess(accountIndex);
-                await saveAccounts(accountStorage);
-                await saveTrackerState(healthTracker, tokenTracker);
-                return response;
-              }
-            },
-          };
-        },
-        methods: [
-          {
-            label: "Qwen OAuth",
-            type: "oauth",
-            authorize: async () => {
-              const device = await authorizeQwenDevice(oauthOptions);
-              const url =
-                device.verificationUriComplete ?? device.verificationUri;
-              const instructions = `Open ${device.verificationUri} and enter code ${device.userCode}`;
-
-              return {
-                url,
-                method: "auto",
-                instructions,
-                callback: async () => {
-                  const result = await pollQwenDeviceToken(
-                    oauthOptions,
-                    device.deviceCode,
-                    device.intervalSeconds,
-                    device.expiresAt,
-                    device.codeVerifier,
-                  );
-                  if (result.type === "success") {
-                    return {
-                      type: "success",
-                      refresh: result.refresh,
-                      access: result.access,
-                      expires: result.expires,
-                      resourceUrl: result.resourceUrl,
-                    };
-                  }
-                  return { type: "failed", error: result.error };
-                },
-              };
-            },
+              },
+            };
           },
-        ],
-      },
+          methods: [
+            {
+              label: "Qwen OAuth",
+              type: "oauth",
+              authorize: async () => {
+                const device = await authorizeQwenDevice(oauthOptions);
+                const url =
+                  device.verificationUriComplete ?? device.verificationUri;
+                const instructions = `Open ${device.verificationUri} and enter code ${device.userCode}`;
+
+                return {
+                  url,
+                  method: "auto",
+                  instructions,
+                  callback: async () => {
+                    const result = await pollQwenDeviceToken(
+                      oauthOptions,
+                      device.deviceCode,
+                      device.intervalSeconds,
+                      device.expiresAt,
+                      device.codeVerifier,
+                    );
+                    if (result.type === "success") {
+                      return {
+                        type: "success",
+                        refresh: result.refresh,
+                        access: result.access,
+                        expires: result.expires,
+                        resourceUrl: result.resourceUrl,
+                      };
+                    }
+                    return { type: "failed", error: result.error };
+                  },
+                };
+              },
+            },
+          ],
+        },
+      };
     };
-  };
 
 export const QwenCLIOAuthPlugin = createQwenOAuthPlugin("qwen");
 export const QwenOAuthPlugin = QwenCLIOAuthPlugin;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -220,23 +220,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function deleteAccount(storage: AccountStorage, index: number): AccountStorage {
-  if (index < 0 || index >= storage.accounts.length) {
-    return storage;
-  }
-  const accounts = storage.accounts.filter((_, i) => i !== index);
-  if (accounts.length === 0) {
-    return { version: 1, accounts: [], activeIndex: 0 };
-  }
-  let activeIndex = storage.activeIndex;
-  if (index < activeIndex) {
-    activeIndex -= 1;
-  } else if (index === activeIndex) {
-    activeIndex = Math.min(activeIndex, accounts.length - 1);
-  }
-  return { version: 1, accounts, activeIndex };
-}
-
 async function ensureAuthInStorage(
   storage: AccountStorage | null,
   auth: OAuthAuthDetails,
@@ -259,22 +242,22 @@ function initializeTrackers(config: LoadedConfig): void {
   initHealthTracker(
     config.health_score
       ? {
-        initial: config.health_score.initial,
-        successReward: config.health_score.success_reward,
-        rateLimitPenalty: config.health_score.rate_limit_penalty,
-        failurePenalty: config.health_score.failure_penalty,
-        recoveryRatePerHour: config.health_score.recovery_rate_per_hour,
-        minUsable: config.health_score.min_usable,
-      }
+          initial: config.health_score.initial,
+          successReward: config.health_score.success_reward,
+          rateLimitPenalty: config.health_score.rate_limit_penalty,
+          failurePenalty: config.health_score.failure_penalty,
+          recoveryRatePerHour: config.health_score.recovery_rate_per_hour,
+          minUsable: config.health_score.min_usable,
+        }
       : undefined,
   );
   initTokenTracker(
     config.token_bucket
       ? {
-        maxTokens: config.token_bucket.max_tokens,
-        regenerationRatePerMinute:
-          config.token_bucket.regeneration_rate_per_minute,
-      }
+          maxTokens: config.token_bucket.max_tokens,
+          regenerationRatePerMinute:
+            config.token_bucket.regeneration_rate_per_minute,
+        }
       : undefined,
   );
 }
@@ -286,422 +269,407 @@ function getPidOffset(config: LoadedConfig): number {
 
 export const createQwenOAuthPlugin =
   (providerId: string): Plugin =>
-    async ({ client, directory }: PluginContext) => {
-      const config = loadConfig(directory);
-      setLoggerQuietMode(config.quiet_mode);
-      initDebugFromEnv();
-      initializeTrackers(config);
-      const existingStorage = await loadAccounts();
-      await loadTrackerState(
-        getHealthTracker(),
-        getTokenTracker(),
-        existingStorage?.accounts,
-      );
+  async ({ client, directory }: PluginContext) => {
+    const config = loadConfig(directory);
+    setLoggerQuietMode(config.quiet_mode);
+    initDebugFromEnv();
+    initializeTrackers(config);
+    const existingStorage = await loadAccounts();
+    await loadTrackerState(
+      getHealthTracker(),
+      getTokenTracker(),
+      existingStorage?.accounts,
+    );
 
-      const pidOffset = getPidOffset(config);
-      logger.debug("Plugin initialized", {
-        providerId,
-        directory,
-        strategy: config.rotation_strategy,
-        pidOffset: config.pid_offset_enabled ? pidOffset : "disabled",
-      });
+    const pidOffset = getPidOffset(config);
+    logger.debug("Plugin initialized", {
+      providerId,
+      directory,
+      strategy: config.rotation_strategy,
+      pidOffset: config.pid_offset_enabled ? pidOffset : "disabled",
+    });
 
-      const oauthOptions = buildOAuthOptions(config);
+    const oauthOptions = buildOAuthOptions(config);
 
-      return {
-        auth: {
-          provider: providerId,
-          async loader(getAuth: GetAuth, provider: Provider) {
-            const auth = (await getAuth()) as AuthDetails;
-            if (!isOAuthAuth(auth)) {
-              return {};
-            }
+    return {
+      auth: {
+        provider: providerId,
+        async loader(getAuth: GetAuth, provider: Provider) {
+          const auth = (await getAuth()) as AuthDetails;
+          if (!isOAuthAuth(auth)) {
+            return {};
+          }
 
-            let accountStorage = await ensureAuthInStorage(
-              existingStorage ?? (await loadAccounts()),
-              auth,
-            );
+          let accountStorage = await ensureAuthInStorage(
+            existingStorage ?? (await loadAccounts()),
+            auth,
+          );
 
-            if (provider.models) {
-              for (const model of Object.values(provider.models)) {
-                if (model) {
-                  model.cost = {
-                    input: 0,
-                    output: 0,
-                    cache: { read: 0, write: 0 },
-                  };
-                }
+          if (provider.models) {
+            for (const model of Object.values(provider.models)) {
+              if (model) {
+                model.cost = {
+                  input: 0,
+                  output: 0,
+                  cache: { read: 0, write: 0 },
+                };
               }
             }
+          }
 
-            return {
-              apiKey: "",
-              fetch: async (
-                input: RequestInfo | URL,
-                init?: RequestInit,
-              ): Promise<Response> => {
-                let attempts = 0;
-                const healthTracker = getHealthTracker();
-                const tokenTracker = getTokenTracker();
-                const selectOptions: SelectAccountOptions = {
-                  healthTracker,
-                  tokenTracker,
-                  pidOffset,
-                };
+          return {
+            apiKey: "",
+            fetch: async (
+              input: RequestInfo | URL,
+              init?: RequestInit,
+            ): Promise<Response> => {
+              let attempts = 0;
+              const healthTracker = getHealthTracker();
+              const tokenTracker = getTokenTracker();
+              const selectOptions: SelectAccountOptions = {
+                healthTracker,
+                tokenTracker,
+                pidOffset,
+              };
 
-                while (true) {
-                  const now = Date.now();
-                  const selection = selectAccount(
-                    accountStorage,
-                    config.rotation_strategy,
-                    now,
-                    selectOptions,
-                  );
+              while (true) {
+                const now = Date.now();
+                const selection = selectAccount(
+                  accountStorage,
+                  config.rotation_strategy,
+                  now,
+                  selectOptions,
+                );
 
-                  if (!selection) {
-                    const waitMs = getMinRateLimitWait(accountStorage, now);
-                    if (!waitMs) {
-                      throw new Error(
-                        "No available Qwen OAuth accounts. Re-authenticate to continue.",
-                      );
-                    }
-
-                    const maxWaitMs =
-                      (config.max_rate_limit_wait_seconds ?? 0) * 1000;
-                    if (maxWaitMs > 0 && waitMs > maxWaitMs) {
-                      throw new Error(
-                        "All Qwen OAuth accounts are rate-limited. Try again later.",
-                      );
-                    }
-
-                    await sleep(waitMs);
-                    continue;
+                if (!selection) {
+                  const waitMs = getMinRateLimitWait(accountStorage, now);
+                  if (!waitMs) {
+                    throw new Error(
+                      "No available Qwen OAuth accounts. Re-authenticate to continue.",
+                    );
                   }
 
-                  accountStorage = selection.storage;
-                  const account = selection.account;
-                  const accountIndex = selection.index;
+                  const maxWaitMs =
+                    (config.max_rate_limit_wait_seconds ?? 0) * 1000;
+                  if (maxWaitMs > 0 && waitMs > maxWaitMs) {
+                    throw new Error(
+                      "All Qwen OAuth accounts are rate-limited. Try again later.",
+                    );
+                  }
 
-                  let activeAuth: OAuthAuthDetails = {
-                    type: "oauth",
-                    refresh: account.refreshToken,
-                    access: account.accessToken,
-                    expires: account.expires,
-                    resourceUrl: account.resourceUrl,
-                  };
+                  await sleep(waitMs);
+                  continue;
+                }
 
-                  const refreshBuffer = config.proactive_refresh
-                    ? config.refresh_window_seconds
-                    : 0;
-                  if (
-                    !activeAuth.access ||
-                    accessTokenExpired(activeAuth, refreshBuffer)
-                  ) {
-                    logger.debug("Token refresh needed", {
+                accountStorage = selection.storage;
+                const account = selection.account;
+                const accountIndex = selection.index;
+
+                let activeAuth: OAuthAuthDetails = {
+                  type: "oauth",
+                  refresh: account.refreshToken,
+                  access: account.accessToken,
+                  expires: account.expires,
+                  resourceUrl: account.resourceUrl,
+                };
+
+                const refreshBuffer = config.proactive_refresh
+                  ? config.refresh_window_seconds
+                  : 0;
+                if (
+                  !activeAuth.access ||
+                  accessTokenExpired(activeAuth, refreshBuffer)
+                ) {
+                  logger.debug("Token refresh needed", {
+                    accountIndex,
+                    hasAccess: !!activeAuth.access,
+                    proactive: config.proactive_refresh,
+                  });
+                  try {
+                    const refreshed = await refreshAccessToken(
+                      activeAuth,
+                      oauthOptions,
+                      client,
+                      providerId,
+                    );
+                    if (!refreshed) {
+                      throw new Error("Token refresh failed");
+                    }
+                    logger.debug("Token refreshed successfully", {
                       accountIndex,
-                      hasAccess: !!activeAuth.access,
-                      proactive: config.proactive_refresh,
                     });
-                    try {
-                      logger.debug("Refreshing token", {
-                        activeAuth,
-                        oauthOptions,
-                        client,
-                        providerId,
-                      });
-                      const refreshed = await refreshAccessToken(
-                        activeAuth,
-                        oauthOptions,
-                        client,
-                        providerId,
-                      );
-                      if (!refreshed) {
-                        throw new Error("Token refresh failed");
-                      }
-                      logger.debug("Token refreshed successfully", {
-                        accountIndex,
-                      });
-                      activeAuth = {
-                        type: "oauth",
-                        refresh: refreshed.refresh,
-                        access: refreshed.access,
+                    activeAuth = {
+                      type: "oauth",
+                      refresh: refreshed.refresh,
+                      access: refreshed.access,
+                      expires: refreshed.expires,
+                      resourceUrl: refreshed.resourceUrl ?? account.resourceUrl,
+                    };
+                    accountStorage = updateAccount(
+                      accountStorage,
+                      accountIndex,
+                      {
+                        refreshToken: refreshed.refresh,
+                        accessToken: refreshed.access,
                         expires: refreshed.expires,
-                        resourceUrl: refreshed.resourceUrl ?? account.resourceUrl,
-                      };
+                        resourceUrl:
+                          refreshed.resourceUrl ?? account.resourceUrl,
+                        lastUsed: now,
+                      },
+                    );
+                    await saveAccounts(accountStorage);
+                  } catch (error) {
+                    const refreshError = error as QwenTokenRefreshError;
+                    logger.debug("Token refresh failed", {
+                      accountIndex,
+                      code: refreshError.code,
+                    });
+                    const permanentTokenErrors = [
+                      "invalid_grant",
+                      "invalid_token",
+                    ];
+                    if (
+                      permanentTokenErrors.includes(refreshError.code ?? "")
+                    ) {
+                      logger.debug(
+                        "Refresh token revoked for account, marking as requiresReauth",
+                        { accountIndex },
+                      );
                       accountStorage = updateAccount(
                         accountStorage,
                         accountIndex,
                         {
-                          refreshToken: refreshed.refresh,
-                          accessToken: refreshed.access,
-                          expires: refreshed.expires,
-                          resourceUrl:
-                            refreshed.resourceUrl ?? account.resourceUrl,
-                          lastUsed: now,
+                          requiresReauth: true,
+                          accessToken: undefined,
+                          expires: undefined,
                         },
                       );
                       await saveAccounts(accountStorage);
-                    } catch (error) {
-                      const refreshError = error as QwenTokenRefreshError;
-                      logger.debug("Token refresh failed", {
-                        accountIndex,
-                        code: refreshError.code,
-                      });
-                      if (refreshError.code === "invalid_grant") {
-                        logger.debug(
-                          "Refresh token revoked for account, marking as requiresReauth",
-                          { accountIndex },
-                        );
-                        accountStorage = updateAccount(
-                          accountStorage,
-                          accountIndex,
-                          {
-                            requiresReauth: true,
-                            accessToken: undefined,
-                            expires: undefined,
-                          },
-                        );
-                        await saveAccounts(accountStorage);
-                        attempts += 1;
-                        if (attempts >= accountStorage.accounts.length) {
-                          throw error;
-                        }
-                        continue;
-                      }
-                      logger.debug("Removing account after refresh failure", {
-                        accountIndex,
-                        code: refreshError.code,
-                      });
-                      accountStorage = deleteAccount(
-                        accountStorage,
-                        accountIndex,
-                      );
-                      await saveAccounts(accountStorage);
-                      healthTracker.removeAccountAt(accountIndex);
-                      tokenTracker.removeAccountAt(accountIndex);
-                      await saveTrackerState(healthTracker, tokenTracker);
-                      if (accountStorage.accounts.length === 0) {
+                      attempts += 1;
+                      if (attempts >= accountStorage.accounts.length) {
                         throw error;
                       }
                       continue;
                     }
+                    throw error;
                   }
+                }
 
-                  // Get URL from input - OpenCode already constructs full URLs
-                  let rawUrl: string;
-                  if (typeof input === "string") {
-                    rawUrl = input;
-                  } else if (input instanceof URL) {
-                    rawUrl = input.toString();
-                  } else {
-                    rawUrl = input.url;
-                  }
+                // Get URL from input - OpenCode already constructs full URLs
+                let rawUrl: string;
+                if (typeof input === "string") {
+                  rawUrl = input;
+                } else if (input instanceof URL) {
+                  rawUrl = input.toString();
+                } else {
+                  rawUrl = input.url;
+                }
 
-                  // Sanitize malformed URLs (e.g., "undefined/path")
-                  rawUrl = sanitizeMalformedUrl(rawUrl);
+                // Sanitize malformed URLs (e.g., "undefined/path")
+                rawUrl = sanitizeMalformedUrl(rawUrl);
 
-                  let requestInit =
-                    init ??
-                    (input instanceof Request
-                      ? {
+                let requestInit =
+                  init ??
+                  (input instanceof Request
+                    ? {
                         method: input.method,
                         headers: input.headers,
                         body: input.body,
                         signal: input.signal,
                       }
-                      : undefined);
+                    : undefined);
 
-                  if (!requestInit && !(input instanceof Request)) {
-                    requestInit = {};
+                if (!requestInit && !(input instanceof Request)) {
+                  requestInit = {};
+                }
+
+                const needsResponsesTransform = rawUrl.endsWith("/responses");
+                const finalUrl = rawUrl.replace(
+                  /\/responses$/,
+                  "/chat/completions",
+                );
+
+                const finalInit = { ...requestInit };
+                if (needsResponsesTransform && requestInit?.body) {
+                  try {
+                    const bodyStr =
+                      typeof requestInit.body === "string"
+                        ? requestInit.body
+                        : await new Response(requestInit.body).text();
+                    const body = JSON.parse(bodyStr);
+                    const transformed =
+                      transformResponsesToChatCompletions(body);
+                    finalInit.body = JSON.stringify(transformed);
+                    logger.verbose("Transformed request body", {
+                      messagesCount: transformed.messages?.length,
+                      hasTools: !!transformed.tools,
+                    });
+                  } catch {
+                    logger.debug("Body parse failed, using original");
                   }
+                }
 
-                  const needsResponsesTransform = rawUrl.endsWith("/responses");
-                  const finalUrl = rawUrl.replace(
-                    /\/responses$/,
-                    "/chat/completions",
+                const headers = transformHeader(requestInit?.headers, {
+                  accessToken: activeAuth.access,
+                  forceJsonContentType: needsResponsesTransform,
+                });
+
+                logger.debug("Sending request", {
+                  url: finalUrl,
+                  method: finalInit.method ?? "POST",
+                  needsTransform: needsResponsesTransform,
+                });
+
+                const response = await fetch(finalUrl, {
+                  ...finalInit,
+                  headers,
+                });
+
+                logger.debug("Response received", {
+                  status: response.status,
+                  contentType: response.headers.get("content-type"),
+                });
+
+                // Transform streaming response from Chat Completions to Responses API format
+                if (
+                  needsResponsesTransform &&
+                  response.ok &&
+                  response.body &&
+                  response.headers
+                    .get("content-type")
+                    ?.includes("text/event-stream")
+                ) {
+                  const sseCtx = createSSETransformContext(logger);
+                  const transformStream = createSSETransformStream(sseCtx);
+                  const transformedBody =
+                    response.body.pipeThrough(transformStream);
+                  return new Response(transformedBody, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers,
+                  });
+                }
+
+                if (
+                  needsResponsesTransform &&
+                  response.ok &&
+                  !response.headers
+                    .get("content-type")
+                    ?.includes("text/event-stream")
+                ) {
+                  logger.debug("Transforming non-streaming response");
+                  const chatBody = await response.json();
+                  const ctx = createTransformContext();
+                  const responsesBody = transformChatCompletionsToResponses(
+                    chatBody,
+                    ctx,
                   );
 
-                  const finalInit = { ...requestInit };
-                  if (needsResponsesTransform && requestInit?.body) {
-                    try {
-                      const bodyStr =
-                        typeof requestInit.body === "string"
-                          ? requestInit.body
-                          : await new Response(requestInit.body).text();
-                      const body = JSON.parse(bodyStr);
-                      const transformed =
-                        transformResponsesToChatCompletions(body);
-                      finalInit.body = JSON.stringify(transformed);
-                      logger.verbose("Transformed request body", {
-                        messagesCount: transformed.messages?.length,
-                        hasTools: !!transformed.tools,
-                      });
-                    } catch {
-                      logger.debug("Body parse failed, using original");
-                    }
-                  }
-
-                  const headers = transformHeader(requestInit?.headers, {
-                    accessToken: activeAuth.access,
-                    forceJsonContentType: needsResponsesTransform,
-                  });
-
-                  logger.debug("Sending request", {
-                    url: finalUrl,
-                    method: finalInit.method ?? "POST",
-                    needsTransform: needsResponsesTransform,
-                  });
-
-                  const response = await fetch(finalUrl, {
-                    ...finalInit,
-                    headers,
-                  });
-
-                  logger.debug("Response received", {
+                  return new Response(JSON.stringify(responsesBody), {
                     status: response.status,
-                    contentType: response.headers.get("content-type"),
+                    statusText: response.statusText,
+                    headers: new Headers({
+                      "content-type": "application/json",
+                    }),
+                  });
+                }
+
+                if (response.status === 429 || response.status >= 500) {
+                  const reason = parseRateLimitReason(response);
+                  const headerMs = extractRetryAfterMs(response);
+                  const tieredMs = getBackoffMs(reason, attempts);
+                  const retryAfterMs = headerMs ?? tieredMs;
+
+                  logger.debug("Rate limited or server error", {
+                    status: response.status,
+                    reason,
+                    accountIndex,
+                    retryAfterMs,
+                    attempts,
+                    totalAccounts: accountStorage.accounts.length,
                   });
 
-                  // Transform streaming response from Chat Completions to Responses API format
-                  if (
-                    needsResponsesTransform &&
-                    response.ok &&
-                    response.body &&
-                    response.headers
-                      .get("content-type")
-                      ?.includes("text/event-stream")
-                  ) {
-                    const sseCtx = createSSETransformContext(logger);
-                    const transformStream = createSSETransformStream(sseCtx);
-                    const transformedBody =
-                      response.body.pipeThrough(transformStream);
-                    return new Response(transformedBody, {
-                      status: response.status,
-                      statusText: response.statusText,
-                      headers: response.headers,
-                    });
+                  accountStorage = markRateLimited(
+                    accountStorage,
+                    accountIndex,
+                    retryAfterMs,
+                  );
+                  accountStorage = recordFailure(accountStorage, accountIndex);
+                  if (response.status === 429) {
+                    healthTracker.recordRateLimit(accountIndex);
+                  } else {
+                    healthTracker.recordFailure(accountIndex);
                   }
-
-                  if (
-                    needsResponsesTransform &&
-                    response.ok &&
-                    !response.headers
-                      .get("content-type")
-                      ?.includes("text/event-stream")
-                  ) {
-                    logger.debug("Transforming non-streaming response");
-                    const chatBody = await response.json();
-                    const ctx = createTransformContext();
-                    const responsesBody = transformChatCompletionsToResponses(
-                      chatBody,
-                      ctx,
-                    );
-
-                    return new Response(JSON.stringify(responsesBody), {
-                      status: response.status,
-                      statusText: response.statusText,
-                      headers: new Headers({
-                        "content-type": "application/json",
-                      }),
-                    });
-                  }
-
-                  if (response.status === 429 || response.status >= 500) {
-                    const reason = parseRateLimitReason(response);
-                    const headerMs = extractRetryAfterMs(response);
-                    const tieredMs = getBackoffMs(reason, attempts);
-                    const retryAfterMs = headerMs ?? tieredMs;
-
-                    logger.debug("Rate limited or server error", {
-                      status: response.status,
-                      reason,
-                      accountIndex,
-                      retryAfterMs,
-                      attempts,
-                      totalAccounts: accountStorage.accounts.length,
-                    });
-
-                    accountStorage = markRateLimited(
-                      accountStorage,
-                      accountIndex,
-                      retryAfterMs,
-                    );
-                    accountStorage = recordFailure(accountStorage, accountIndex);
-                    if (response.status === 429) {
-                      healthTracker.recordRateLimit(accountIndex);
-                    } else {
-                      healthTracker.recordFailure(accountIndex);
-                    }
-                    await saveAccounts(accountStorage);
-                    await saveTrackerState(healthTracker, tokenTracker);
-                    attempts += 1;
-                    if (attempts >= accountStorage.accounts.length) {
-                      const waitMs = getMinRateLimitWait(
-                        accountStorage,
-                        Date.now(),
-                      );
-                      if (waitMs) {
-                        logger.debug("All accounts rate limited, waiting", {
-                          waitMs,
-                        });
-                        await sleep(waitMs);
-                        attempts = 0;
-                        continue;
-                      }
-                      return response;
-                    }
-                    continue;
-                  }
-
-                  accountStorage = recordSuccess(accountStorage, accountIndex);
-                  healthTracker.recordSuccess(accountIndex);
                   await saveAccounts(accountStorage);
                   await saveTrackerState(healthTracker, tokenTracker);
-                  return response;
-                }
-              },
-            };
-          },
-          methods: [
-            {
-              label: "Qwen OAuth",
-              type: "oauth",
-              authorize: async () => {
-                const device = await authorizeQwenDevice(oauthOptions);
-                const url =
-                  device.verificationUriComplete ?? device.verificationUri;
-                const instructions = `Open ${device.verificationUri} and enter code ${device.userCode}`;
-
-                return {
-                  url,
-                  method: "auto",
-                  instructions,
-                  callback: async () => {
-                    const result = await pollQwenDeviceToken(
-                      oauthOptions,
-                      device.deviceCode,
-                      device.intervalSeconds,
-                      device.expiresAt,
-                      device.codeVerifier,
+                  attempts += 1;
+                  if (attempts >= accountStorage.accounts.length) {
+                    const waitMs = getMinRateLimitWait(
+                      accountStorage,
+                      Date.now(),
                     );
-                    if (result.type === "success") {
-                      return {
-                        type: "success",
-                        refresh: result.refresh,
-                        access: result.access,
-                        expires: result.expires,
-                        resourceUrl: result.resourceUrl,
-                      };
+                    if (waitMs) {
+                      logger.debug("All accounts rate limited, waiting", {
+                        waitMs,
+                      });
+                      await sleep(waitMs);
+                      attempts = 0;
+                      continue;
                     }
-                    return { type: "failed", error: result.error };
-                  },
-                };
-              },
+                    return response;
+                  }
+                  continue;
+                }
+
+                accountStorage = recordSuccess(accountStorage, accountIndex);
+                healthTracker.recordSuccess(accountIndex);
+                await saveAccounts(accountStorage);
+                await saveTrackerState(healthTracker, tokenTracker);
+                return response;
+              }
             },
-          ],
+          };
         },
-      };
+        methods: [
+          {
+            label: "Qwen OAuth",
+            type: "oauth",
+            authorize: async () => {
+              const device = await authorizeQwenDevice(oauthOptions);
+              const url =
+                device.verificationUriComplete ?? device.verificationUri;
+              const instructions = `Open ${device.verificationUri} and enter code ${device.userCode}`;
+
+              return {
+                url,
+                method: "auto",
+                instructions,
+                callback: async () => {
+                  const result = await pollQwenDeviceToken(
+                    oauthOptions,
+                    device.deviceCode,
+                    device.intervalSeconds,
+                    device.expiresAt,
+                    device.codeVerifier,
+                  );
+                  if (result.type === "success") {
+                    return {
+                      type: "success",
+                      refresh: result.refresh,
+                      access: result.access,
+                      expires: result.expires,
+                      resourceUrl: result.resourceUrl,
+                    };
+                  }
+                  return { type: "failed", error: result.error };
+                },
+              };
+            },
+          },
+        ],
+      },
     };
+  };
 
 export const QwenCLIOAuthPlugin = createQwenOAuthPlugin("qwen");
 export const QwenOAuthPlugin = QwenCLIOAuthPlugin;

--- a/src/plugin/account.ts
+++ b/src/plugin/account.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
+import { isValidOAuthRefreshToken } from "./auth";
 import type { RotationStrategy } from "./config/schema";
 import {
   type AccountWithMetrics,
@@ -202,7 +203,9 @@ async function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
 }
 
 function normalizeStorage(storage: AccountStorage): AccountStorage {
-  const accounts = storage.accounts.filter((account) => account?.refreshToken);
+  const accounts = storage.accounts.filter((account) =>
+    isValidOAuthRefreshToken(account?.refreshToken),
+  );
   const activeIndex =
     accounts.length > 0
       ? Math.min(Math.max(storage.activeIndex, 0), accounts.length - 1)

--- a/src/plugin/auth.ts
+++ b/src/plugin/auth.ts
@@ -1,10 +1,22 @@
 import type { AuthDetails, OAuthAuthDetails } from "./types";
 
+/**
+ * Rejects empty values and placeholder strings often produced when
+ * `undefined` is stringified into storage or URLSearchParams.
+ */
+export function isValidOAuthRefreshToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== "undefined" &&
+    value !== "null"
+  );
+}
+
 export function isOAuthAuth(auth: AuthDetails): auth is OAuthAuthDetails {
   return (
     auth.type === "oauth" &&
-    typeof auth.refresh === "string" &&
-    auth.refresh.length > 0
+    isValidOAuthRefreshToken((auth as { refresh?: unknown }).refresh)
   );
 }
 

--- a/src/plugin/logger.ts
+++ b/src/plugin/logger.ts
@@ -77,6 +77,7 @@ export function initDebugFromEnv(): void {
     debugLevel = 1;
   } else if (envDebug === "2") {
     debugLevel = 2;
+    console.log("Debug level set to 2");
   } else if (process.env.DEBUG?.includes("qwen")) {
     debugLevel = 1;
   }

--- a/src/plugin/rotation.ts
+++ b/src/plugin/rotation.ts
@@ -151,6 +151,22 @@ export class HealthScoreTracker {
   }
 
   /**
+   * Drop state for removed account and shift higher indices down to match storage order.
+   */
+  removeAccountAt(removedIndex: number): void {
+    const next = new Map<number, HealthScoreState>();
+    for (const [idx, state] of this.scores) {
+      if (idx === removedIndex) continue;
+      const newIdx = idx > removedIndex ? idx - 1 : idx;
+      next.set(newIdx, state);
+    }
+    this.scores.clear();
+    for (const [idx, state] of next) {
+      this.scores.set(idx, state);
+    }
+  }
+
+  /**
    * Export state for persistence.
    */
   toJSON(): Record<string, HealthScoreState> {
@@ -279,6 +295,22 @@ export class TokenBucketTracker {
       tokens: Math.min(this.config.maxTokens, current + amount),
       lastUpdated: Date.now(),
     });
+  }
+
+  /**
+   * Drop bucket for removed account and shift higher indices down to match storage order.
+   */
+  removeAccountAt(removedIndex: number): void {
+    const next = new Map<number, TokenBucketState>();
+    for (const [idx, state] of this.buckets) {
+      if (idx === removedIndex) continue;
+      const newIdx = idx > removedIndex ? idx - 1 : idx;
+      next.set(newIdx, state);
+    }
+    this.buckets.clear();
+    for (const [idx, state] of next) {
+      this.buckets.set(idx, state);
+    }
   }
 
   /**

--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -1,4 +1,5 @@
 import { type QwenOAuthOptions, refreshQwenToken } from "../qwen/oauth";
+import { isValidOAuthRefreshToken } from "./auth";
 import type { OAuthAuthDetails, PluginClient } from "./types";
 
 export class QwenTokenRefreshError extends Error {
@@ -17,6 +18,12 @@ export async function refreshAccessToken(
   client: PluginClient,
   providerId: string,
 ): Promise<OAuthAuthDetails | null> {
+  if (!isValidOAuthRefreshToken(auth.refresh)) {
+    throw new QwenTokenRefreshError(
+      "Missing or invalid refresh token; re-authenticate with Qwen OAuth.",
+      "invalid_request",
+    );
+  }
   const result = await refreshQwenToken(options, auth.refresh);
 
   if (result.type === "failed") {

--- a/src/qwen/oauth.ts
+++ b/src/qwen/oauth.ts
@@ -6,7 +6,7 @@ import {
   QWEN_OAUTH_BASE_URL,
   QWEN_TOKEN_ENDPOINT,
 } from "../constants";
-import { calculateTokenExpiry } from "../plugin/auth";
+import { calculateTokenExpiry, isValidOAuthRefreshToken } from "../plugin/auth";
 import { createLogger } from "../plugin/logger";
 
 const logger = createLogger("oauth");
@@ -218,12 +218,7 @@ export async function refreshQwenToken(
   options: QwenOAuthOptions,
   refreshToken: string,
 ): Promise<QwenTokenResult> {
-  if (
-    typeof refreshToken !== "string" ||
-    refreshToken.length === 0 ||
-    refreshToken === "undefined" ||
-    refreshToken === "null"
-  ) {
+  if (!isValidOAuthRefreshToken(refreshToken)) {
     return {
       type: "failed",
       error: "Missing or invalid refresh token",
@@ -247,18 +242,16 @@ export async function refreshQwenToken(
   );
 
   if (!response.ok) {
-    const body = await response.text();
-    const errorPayload = (await response
-      .json()
-      .catch(() => ({}))) as QwenErrorResponse;
+    const bodyText = await response.text();
+    const errorPayload = (JSON.parse(bodyText) || {}) as QwenErrorResponse;
     logger.debug("Failed to refresh token", {
       url: resolveOAuthUrl(options.oauthBaseUrl, QWEN_TOKEN_ENDPOINT),
-      bodyRequest: createOAuthBody({
+      bodyRequest: {
         client_id: resolveClientId(options.clientId),
         grant_type: "refresh_token",
-        refresh_token: refreshToken,
-      }),
-      bodyResponse: body,
+        refresh_token: "***",
+      },
+      bodyResponse: bodyText,
     });
     return {
       type: "failed",

--- a/src/qwen/oauth.ts
+++ b/src/qwen/oauth.ts
@@ -7,6 +7,9 @@ import {
   QWEN_TOKEN_ENDPOINT,
 } from "../constants";
 import { calculateTokenExpiry } from "../plugin/auth";
+import { createLogger } from "../plugin/logger";
+
+const logger = createLogger("oauth");
 
 export interface QwenOAuthOptions {
   clientId: string;
@@ -215,6 +218,19 @@ export async function refreshQwenToken(
   options: QwenOAuthOptions,
   refreshToken: string,
 ): Promise<QwenTokenResult> {
+  if (
+    typeof refreshToken !== "string" ||
+    refreshToken.length === 0 ||
+    refreshToken === "undefined" ||
+    refreshToken === "null"
+  ) {
+    return {
+      type: "failed",
+      error: "Missing or invalid refresh token",
+      code: "invalid_request",
+    };
+  }
+
   const response = await fetch(
     resolveOAuthUrl(options.oauthBaseUrl, QWEN_TOKEN_ENDPOINT),
     {
@@ -231,9 +247,19 @@ export async function refreshQwenToken(
   );
 
   if (!response.ok) {
+    const body = await response.text();
     const errorPayload = (await response
       .json()
       .catch(() => ({}))) as QwenErrorResponse;
+    logger.debug("Failed to refresh token", {
+      url: resolveOAuthUrl(options.oauthBaseUrl, QWEN_TOKEN_ENDPOINT),
+      bodyRequest: createOAuthBody({
+        client_id: resolveClientId(options.clientId),
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }),
+      bodyResponse: body,
+    });
     return {
       type: "failed",
       error: errorPayload.error_description ?? "Failed to refresh token",

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { accessTokenExpired } from "../src/plugin/auth";
+import { accessTokenExpired, isOAuthAuth } from "../src/plugin/auth";
+import type { AuthDetails } from "../src/plugin/types";
 
 const baseAuth = {
   type: "oauth" as const,
@@ -20,5 +21,36 @@ describe("accessTokenExpired", () => {
   it("uses buffer window", () => {
     const auth = { ...baseAuth, expires: Date.now() + 5_000 };
     expect(accessTokenExpired(auth, 10)).toBe(true);
+  });
+});
+
+describe("isOAuthAuth", () => {
+  it("accepts a normal refresh token", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "real-token",
+    };
+    expect(isOAuthAuth(auth)).toBe(true);
+  });
+
+  it("rejects the literal string undefined", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "undefined",
+    };
+    expect(isOAuthAuth(auth)).toBe(false);
+  });
+
+  it("rejects the literal string null", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "null",
+    };
+    expect(isOAuthAuth(auth)).toBe(false);
+  });
+
+  it("rejects empty refresh", () => {
+    const auth: AuthDetails = { type: "oauth", refresh: "" };
+    expect(isOAuthAuth(auth)).toBe(false);
   });
 });

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, mock } from "bun:test";
-import { refreshAccessToken } from "../src/plugin/token";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { QwenTokenRefreshError, refreshAccessToken } from "../src/plugin/token";
 import type { OAuthAuthDetails, PluginClient } from "../src/plugin/types";
 
 const mockRefreshQwenToken = mock(() =>
@@ -15,6 +15,10 @@ const mockRefreshQwenToken = mock(() =>
 mock.module("../src/qwen/oauth", () => ({
   refreshQwenToken: mockRefreshQwenToken,
 }));
+
+afterEach(() => {
+  mockRefreshQwenToken.mockClear();
+});
 
 describe("refreshAccessToken", () => {
   it("persists updated auth details", async () => {
@@ -51,5 +55,28 @@ describe("refreshAccessToken", () => {
         resourceUrl: "https://resource.example",
       },
     });
+  });
+
+  it("does not call the token endpoint when refresh is the string undefined", async () => {
+    const auth = {
+      type: "oauth" as const,
+      refresh: "undefined",
+      access: "access-old",
+    } as OAuthAuthDetails;
+
+    const client = {
+      auth: { set: mock(() => Promise.resolve(undefined)) },
+    } as unknown as PluginClient;
+
+    await expect(
+      refreshAccessToken(
+        auth,
+        { clientId: "client", oauthBaseUrl: "https://chat.qwen.ai" },
+        client,
+        "qwen",
+      ),
+    ).rejects.toThrow(QwenTokenRefreshError);
+
+    expect(mockRefreshQwenToken).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Added a `deleteAccount` function to manage account removal from storage, adjusting active indices accordingly.
- Introduced `isValidOAuthRefreshToken` utility to validate refresh tokens, ensuring they are not empty or placeholder values.
- Updated account normalization to filter out accounts with invalid refresh tokens.
- Enhanced token refresh logic to handle invalid refresh tokens gracefully, throwing appropriate errors.
- Added tests for new validation logic and account handling to ensure robustness.

## Summary
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [ ] 🐛 Bug fix
- [X] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 Config/CI

## Self-Review Checklist
- [X] Code compiles and tests pass (`bun test`)
- [X] Lint passes (`bun run lint`)
- [X] Build succeeds (`bun run build`)
- [X] Changes are covered by tests (if applicable)
- [ ] README/AGENTS.md updated (if applicable)
- [ ] No hardcoded secrets or credentials
- [ ] Commit messages are clear and descriptive

## Related Issues
<!-- Use "Closes #123" to auto-close issues -->
Closes #

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens refresh-token validation and marks accounts with permanent token errors for re‑auth instead of deleting them, keeping rotation healthy and avoiding blocked requests. Invalid or placeholder refresh tokens are filtered out, and refresh skips the OAuth endpoint for them.

- **New Features**
  - Added `isValidOAuthRefreshToken` and wired it into `isOAuthAuth`.
  - Normalize stored accounts to drop `""`, `"undefined"`, and `"null"` refresh tokens.
  - Treat `invalid_grant` and `invalid_token` as permanent; mark account `requiresReauth` and continue rotation.
  - Improved OAuth refresh debug logs with request/response details.

- **Bug Fixes**
  - Skip token endpoint when refresh token is invalid; throw `QwenTokenRefreshError` with `invalid_request`.
  - Stop auto-continuing on non-permanent refresh errors; surface them to callers.
  - Added tests for token validation and refresh paths to ensure invalid tokens never hit the endpoint.

<sup>Written for commit f84d4ecc9f5ae9796e498341bb9ef09a4329d86f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

