### PR TITLE
fix: emit completion events in flush when stream terminates without [DONE]

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode-qwencode-oauth",
       "dependencies": {
         "prompts": "^2.4.2",
-        "proper-lockfile": "^4.1.2",
         "zod": "^3.24.0",
       },
       "devDependencies": {
@@ -14,7 +12,6 @@
         "@opencode-ai/plugin": "^1.0.150",
         "@types/bun": "^1.3.6",
         "@types/node": "^24.10.1",
-        "@types/proper-lockfile": "^4.1.4",
         "typescript": "^5.0.0",
       },
       "peerDependencies": {
@@ -24,242 +21,46 @@
     },
   },
   "packages": {
-    "@biomejs/biome": [
-      "@biomejs/biome@2.3.11",
-      "",
-      {
-        "optionalDependencies": {
-          "@biomejs/cli-darwin-arm64": "2.3.11",
-          "@biomejs/cli-darwin-x64": "2.3.11",
-          "@biomejs/cli-linux-arm64": "2.3.11",
-          "@biomejs/cli-linux-arm64-musl": "2.3.11",
-          "@biomejs/cli-linux-x64": "2.3.11",
-          "@biomejs/cli-linux-x64-musl": "2.3.11",
-          "@biomejs/cli-win32-arm64": "2.3.11",
-          "@biomejs/cli-win32-x64": "2.3.11"
-        },
-        "bin": {
-          "biome": "bin/biome"
-        }
-      },
-      "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="
-    ],
-    "@biomejs/cli-darwin-arm64": [
-      "@biomejs/cli-darwin-arm64@2.3.11",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "arm64"
-      },
-      "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="
-    ],
-    "@biomejs/cli-darwin-x64": [
-      "@biomejs/cli-darwin-x64@2.3.11",
-      "",
-      {
-        "os": "darwin",
-        "cpu": "x64"
-      },
-      "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="
-    ],
-    "@biomejs/cli-linux-arm64": [
-      "@biomejs/cli-linux-arm64@2.3.11",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="
-    ],
-    "@biomejs/cli-linux-arm64-musl": [
-      "@biomejs/cli-linux-arm64-musl@2.3.11",
-      "",
-      {
-        "os": "linux",
-        "cpu": "arm64"
-      },
-      "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="
-    ],
-    "@biomejs/cli-linux-x64": [
-      "@biomejs/cli-linux-x64@2.3.11",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="
-    ],
-    "@biomejs/cli-linux-x64-musl": [
-      "@biomejs/cli-linux-x64-musl@2.3.11",
-      "",
-      {
-        "os": "linux",
-        "cpu": "x64"
-      },
-      "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="
-    ],
-    "@biomejs/cli-win32-arm64": [
-      "@biomejs/cli-win32-arm64@2.3.11",
-      "",
-      {
-        "os": "win32",
-        "cpu": "arm64"
-      },
-      "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="
-    ],
-    "@biomejs/cli-win32-x64": [
-      "@biomejs/cli-win32-x64@2.3.11",
-      "",
-      {
-        "os": "win32",
-        "cpu": "x64"
-      },
-      "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="
-    ],
-    "@opencode-ai/plugin": [
-      "@opencode-ai/plugin@1.1.25",
-      "",
-      {
-        "dependencies": {
-          "@opencode-ai/sdk": "1.1.25",
-          "zod": "4.1.8"
-        }
-      },
-      "sha512-oTUWS446H/j7z3pdzo3cOrB5N87XZ/RKdgPD8yHv/rLX92B4YQHjOqggVQ56Q+1VEnN0jxzhoqRylv/0ZEts/Q=="
-    ],
-    "@opencode-ai/sdk": [
-      "@opencode-ai/sdk@1.1.25",
-      "",
-      {},
-      "sha512-mWUX489ArEF2ICg3iZsx2VQaGS3Z2j/dwAJDacao9t7dGDzjOIaacPw2weZ10zld7XmT9V9C0PM/A5lDZ52J+w=="
-    ],
-    "@types/bun": [
-      "@types/bun@1.3.6",
-      "",
-      {
-        "dependencies": {
-          "bun-types": "1.3.6"
-        }
-      },
-      "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="
-    ],
-    "@types/node": [
-      "@types/node@24.10.9",
-      "",
-      {
-        "dependencies": {
-          "undici-types": "7.16.0"
-        }
-      },
-      "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="
-    ],
-    "@types/proper-lockfile": [
-      "@types/proper-lockfile@4.1.4",
-      "",
-      {
-        "dependencies": {
-          "@types/retry": "0.12.5"
-        }
-      },
-      "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="
-    ],
-    "@types/retry": [
-      "@types/retry@0.12.5",
-      "",
-      {},
-      "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw=="
-    ],
-    "bun-types": [
-      "bun-types@1.3.6",
-      "",
-      {
-        "dependencies": {
-          "@types/node": "*"
-        }
-      },
-      "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="
-    ],
-    "graceful-fs": [
-      "graceful-fs@4.2.11",
-      "",
-      {},
-      "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    ],
-    "kleur": [
-      "kleur@3.0.3",
-      "",
-      {},
-      "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
-    ],
-    "prompts": [
-      "prompts@2.4.2",
-      "",
-      {
-        "dependencies": {
-          "kleur": "^3.0.3",
-          "sisteransi": "^1.0.5"
-        }
-      },
-      "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="
-    ],
-    "proper-lockfile": [
-      "proper-lockfile@4.1.2",
-      "",
-      {
-        "dependencies": {
-          "graceful-fs": "4.2.11",
-          "retry": "0.12.0",
-          "signal-exit": "3.0.7"
-        }
-      },
-      "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="
-    ],
-    "retry": [
-      "retry@0.12.0",
-      "",
-      {},
-      "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
-    ],
-    "signal-exit": [
-      "signal-exit@3.0.7",
-      "",
-      {},
-      "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    ],
-    "sisteransi": [
-      "sisteransi@1.0.5",
-      "",
-      {},
-      "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
-    ],
-    "typescript": [
-      "typescript@5.9.3",
-      "",
-      {
-        "bin": {
-          "tsc": "bin/tsc",
-          "tsserver": "bin/tsserver"
-        }
-      },
-      "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
-    ],
-    "undici-types": [
-      "undici-types@7.16.0",
-      "",
-      {},
-      "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
-    ],
-    "zod": [
-      "zod@3.25.76",
-      "",
-      {},
-      "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
-    ],
-    "@opencode-ai/plugin/zod": [
-      "zod@4.1.8",
-      "",
-      {},
-      "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="
-    ],
+    "@biomejs/biome": ["@biomejs/biome@2.3.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.11", "@biomejs/cli-darwin-x64": "2.3.11", "@biomejs/cli-linux-arm64": "2.3.11", "@biomejs/cli-linux-arm64-musl": "2.3.11", "@biomejs/cli-linux-x64": "2.3.11", "@biomejs/cli-linux-x64-musl": "2.3.11", "@biomejs/cli-win32-arm64": "2.3.11", "@biomejs/cli-win32-x64": "2.3.11" }, "bin": { "biome": "bin/biome" } }, "sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.3.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.3.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.3.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.3.11", "", { "os": "linux", "cpu": "x64" }, "sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.11", "", { "os": "win32", "cpu": "x64" }, "sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.1.25", "", { "dependencies": { "@opencode-ai/sdk": "1.1.25", "zod": "4.1.8" } }, "sha512-oTUWS446H/j7z3pdzo3cOrB5N87XZ/RKdgPD8yHv/rLX92B4YQHjOqggVQ56Q+1VEnN0jxzhoqRylv/0ZEts/Q=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.25", "", {}, "sha512-mWUX489ArEF2ICg3iZsx2VQaGS3Z2j/dwAJDacao9t7dGDzjOIaacPw2weZ10zld7XmT9V9C0PM/A5lDZ52J+w=="],
+
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/node": ["@types/node@24.10.9", "", { "dependencies": { "undici-types": "7.16.0" } }, "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+
+    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@opencode-ai/plugin/zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-qwencode-oauth",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Qwen OAuth authentication plugin for OpenCode with multi-account rotation and API translation",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -74,12 +74,10 @@
     "@opencode-ai/plugin": "^1.0.150",
     "@types/bun": "^1.3.6",
     "@types/node": "^24.10.1",
-    "@types/proper-lockfile": "^4.1.4",
     "typescript": "^5.0.0"
   },
   "dependencies": {
     "prompts": "^2.4.2",
-    "proper-lockfile": "^4.1.2",
     "zod": "^3.24.0"
   }
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -424,7 +424,13 @@ export const createQwenOAuthPlugin =
                       accountIndex,
                       code: refreshError.code,
                     });
-                    if (refreshError.code === "invalid_grant") {
+                    const permanentTokenErrors = [
+                      "invalid_grant",
+                      "invalid_token",
+                    ];
+                    if (
+                      permanentTokenErrors.includes(refreshError.code ?? "")
+                    ) {
                       logger.debug(
                         "Refresh token revoked for account, marking as requiresReauth",
                         { accountIndex },
@@ -439,14 +445,13 @@ export const createQwenOAuthPlugin =
                         },
                       );
                       await saveAccounts(accountStorage);
-                    } else {
-                      tokenTracker.refund(accountIndex);
+                      attempts += 1;
+                      if (attempts >= accountStorage.accounts.length) {
+                        throw error;
+                      }
+                      continue;
                     }
-                    attempts += 1;
-                    if (attempts >= accountStorage.accounts.length) {
-                      throw error;
-                    }
-                    continue;
+                    throw error;
                   }
                 }
 

--- a/src/plugin/account.ts
+++ b/src/plugin/account.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import lockfile from "proper-lockfile";
+import { isValidOAuthRefreshToken } from "./auth";
 import type { RotationStrategy } from "./config/schema";
 import {
   type AccountWithMetrics,
@@ -14,6 +14,76 @@ import {
   type TokenBucketState,
   type TokenBucketTracker,
 } from "./rotation";
+
+/**
+ * Acquire an exclusive file lock using atomic mkdir (same technique as
+ * proper-lockfile). Returns a release function.
+ */
+async function acquireFileLock(
+  filePath: string,
+  opts: {
+    stale: number;
+    retries: {
+      retries: number;
+      minTimeout: number;
+      maxTimeout: number;
+      factor: number;
+    };
+  },
+): Promise<() => Promise<void>> {
+  const lockDir = `${filePath}.lock`;
+  const pidFile = join(lockDir, "pid");
+  const { stale, retries: r } = opts;
+  let attempt = 0;
+  let delay = r.minTimeout;
+
+  for (; ;) {
+    try {
+      await fs.mkdir(lockDir);
+      await fs
+        .writeFile(
+          pidFile,
+          JSON.stringify({ pid: process.pid, time: Date.now() }),
+          "utf-8",
+        )
+        .catch(() => undefined);
+      return async () => {
+        await fs
+          .rm(lockDir, { recursive: true, force: true })
+          .catch(() => undefined);
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") throw err;
+
+      // Check staleness using directory mtime (available immediately after mkdir)
+      // This avoids race condition where pid file hasn't been written yet
+      try {
+        const stat = await fs.stat(lockDir);
+        const lockAge = Date.now() - stat.mtimeMs;
+        if (lockAge > stale) {
+          await fs
+            .rm(lockDir, { recursive: true, force: true })
+            .catch(() => undefined);
+          continue;
+        }
+      } catch {
+        await fs
+          .rm(lockDir, { recursive: true, force: true })
+          .catch(() => undefined);
+        continue;
+      }
+
+      if (attempt >= r.retries) {
+        throw new Error(
+          `[qwen-oauth] Could not acquire lock on ${filePath} after ${r.retries} attempts`,
+        );
+      }
+      await new Promise<void>((res) => setTimeout(res, delay));
+      delay = Math.min(delay * r.factor, r.maxTimeout);
+      attempt++;
+    }
+  }
+}
 
 export type { RotationStrategy } from "./config/schema";
 
@@ -185,14 +255,9 @@ async function ensureFileExists(path: string): Promise<void> {
 
 async function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
   await ensureFileExists(path);
-  const release = await lockfile.lock(path, {
+  const release = await acquireFileLock(path, {
     stale: 10000,
-    retries: {
-      retries: 5,
-      minTimeout: 100,
-      maxTimeout: 1000,
-      factor: 2,
-    },
+    retries: { retries: 5, minTimeout: 100, maxTimeout: 1000, factor: 2 },
   });
   try {
     return await fn();
@@ -202,7 +267,9 @@ async function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
 }
 
 function normalizeStorage(storage: AccountStorage): AccountStorage {
-  const accounts = storage.accounts.filter((account) => account?.refreshToken);
+  const accounts = storage.accounts.filter((account) =>
+    isValidOAuthRefreshToken(account?.refreshToken),
+  );
   const activeIndex =
     accounts.length > 0
       ? Math.min(Math.max(storage.activeIndex, 0), accounts.length - 1)

--- a/src/plugin/auth.ts
+++ b/src/plugin/auth.ts
@@ -1,10 +1,22 @@
 import type { AuthDetails, OAuthAuthDetails } from "./types";
 
+/**
+ * Rejects empty values and placeholder strings often produced when
+ * `undefined` is stringified into storage or URLSearchParams.
+ */
+export function isValidOAuthRefreshToken(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value !== "undefined" &&
+    value !== "null"
+  );
+}
+
 export function isOAuthAuth(auth: AuthDetails): auth is OAuthAuthDetails {
   return (
     auth.type === "oauth" &&
-    typeof auth.refresh === "string" &&
-    auth.refresh.length > 0
+    isValidOAuthRefreshToken((auth as { refresh?: unknown }).refresh)
   );
 }
 

--- a/src/plugin/logger.ts
+++ b/src/plugin/logger.ts
@@ -77,6 +77,7 @@ export function initDebugFromEnv(): void {
     debugLevel = 1;
   } else if (envDebug === "2") {
     debugLevel = 2;
+    console.log("Debug level set to 2");
   } else if (process.env.DEBUG?.includes("qwen")) {
     debugLevel = 1;
   }

--- a/src/plugin/rotation.ts
+++ b/src/plugin/rotation.ts
@@ -151,6 +151,22 @@ export class HealthScoreTracker {
   }
 
   /**
+   * Drop state for removed account and shift higher indices down to match storage order.
+   */
+  removeAccountAt(removedIndex: number): void {
+    const next = new Map<number, HealthScoreState>();
+    for (const [idx, state] of this.scores) {
+      if (idx === removedIndex) continue;
+      const newIdx = idx > removedIndex ? idx - 1 : idx;
+      next.set(newIdx, state);
+    }
+    this.scores.clear();
+    for (const [idx, state] of next) {
+      this.scores.set(idx, state);
+    }
+  }
+
+  /**
    * Export state for persistence.
    */
   toJSON(): Record<string, HealthScoreState> {
@@ -279,6 +295,22 @@ export class TokenBucketTracker {
       tokens: Math.min(this.config.maxTokens, current + amount),
       lastUpdated: Date.now(),
     });
+  }
+
+  /**
+   * Drop bucket for removed account and shift higher indices down to match storage order.
+   */
+  removeAccountAt(removedIndex: number): void {
+    const next = new Map<number, TokenBucketState>();
+    for (const [idx, state] of this.buckets) {
+      if (idx === removedIndex) continue;
+      const newIdx = idx > removedIndex ? idx - 1 : idx;
+      next.set(newIdx, state);
+    }
+    this.buckets.clear();
+    for (const [idx, state] of next) {
+      this.buckets.set(idx, state);
+    }
   }
 
   /**

--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -1,4 +1,5 @@
 import { type QwenOAuthOptions, refreshQwenToken } from "../qwen/oauth";
+import { isValidOAuthRefreshToken } from "./auth";
 import type { OAuthAuthDetails, PluginClient } from "./types";
 
 export class QwenTokenRefreshError extends Error {
@@ -17,6 +18,12 @@ export async function refreshAccessToken(
   client: PluginClient,
   providerId: string,
 ): Promise<OAuthAuthDetails | null> {
+  if (!isValidOAuthRefreshToken(auth.refresh)) {
+    throw new QwenTokenRefreshError(
+      "Missing or invalid refresh token; re-authenticate with Qwen OAuth.",
+      "invalid_request",
+    );
+  }
   const result = await refreshQwenToken(options, auth.refresh);
 
   if (result.type === "failed") {

--- a/src/qwen/oauth.ts
+++ b/src/qwen/oauth.ts
@@ -6,7 +6,10 @@ import {
   QWEN_OAUTH_BASE_URL,
   QWEN_TOKEN_ENDPOINT,
 } from "../constants";
-import { calculateTokenExpiry } from "../plugin/auth";
+import { calculateTokenExpiry, isValidOAuthRefreshToken } from "../plugin/auth";
+import { createLogger } from "../plugin/logger";
+
+const logger = createLogger("oauth");
 
 export interface QwenOAuthOptions {
   clientId: string;
@@ -215,6 +218,14 @@ export async function refreshQwenToken(
   options: QwenOAuthOptions,
   refreshToken: string,
 ): Promise<QwenTokenResult> {
+  if (!isValidOAuthRefreshToken(refreshToken)) {
+    return {
+      type: "failed",
+      error: "Missing or invalid refresh token",
+      code: "invalid_request",
+    };
+  }
+
   const response = await fetch(
     resolveOAuthUrl(options.oauthBaseUrl, QWEN_TOKEN_ENDPOINT),
     {
@@ -231,9 +242,17 @@ export async function refreshQwenToken(
   );
 
   if (!response.ok) {
-    const errorPayload = (await response
-      .json()
-      .catch(() => ({}))) as QwenErrorResponse;
+    const bodyText = await response.text();
+    const errorPayload = (JSON.parse(bodyText) || {}) as QwenErrorResponse;
+    logger.debug("Failed to refresh token", {
+      url: resolveOAuthUrl(options.oauthBaseUrl, QWEN_TOKEN_ENDPOINT),
+      bodyRequest: {
+        client_id: resolveClientId(options.clientId),
+        grant_type: "refresh_token",
+        refresh_token: "***",
+      },
+      bodyResponse: bodyText,
+    });
     return {
       type: "failed",
       error: errorPayload.error_description ?? "Failed to refresh token",

--- a/src/transform/sse.ts
+++ b/src/transform/sse.ts
@@ -36,6 +36,7 @@ export function createSSETransformStream(
   let sentCreated = false;
   let sentItemAdded = false;
   let sentContentPartAdded = false;
+  let sentCompleted = false;
   let messageOutputIndex = -1;
   let inputTokens = 0;
   let outputTokens = 0;
@@ -141,6 +142,7 @@ export function createSSETransformStream(
               },
             }),
           );
+          sentCompleted = true;
           controller.enqueue(encoder.encode("data: [DONE]\n\n"));
           continue;
         }
@@ -277,44 +279,149 @@ export function createSSETransformStream(
       }
     },
     flush(controller) {
+      if (sentCompleted) return;
+
       buffer += decoder.decode();
       const trimmed = buffer.trim();
-      if (!trimmed) return;
 
       ctx.logger?.verbose("Flush remaining SSE buffer", {
         length: trimmed.length,
       });
 
-      if (!trimmed.startsWith("data: ")) return;
-      const data = trimmed.slice(6).trim();
-      if (!data || data === "[DONE]") return;
-
-      try {
-        const parsed = JSON.parse(data);
-        if (parsed.model) modelName = parsed.model;
-        const usage = parsed.usage;
-        if (usage) {
-          inputTokens = usage.prompt_tokens ?? inputTokens;
-          outputTokens = usage.completion_tokens ?? outputTokens;
+      if (trimmed) {
+        if (!trimmed.startsWith("data: ")) {
+          ctx.logger?.verbose("Flush: non-data buffer, skipping parse", {
+            buffer: trimmed.slice(0, 100),
+          });
+        } else {
+          const data = trimmed.slice(6).trim();
+          if (data && data !== "[DONE]") {
+            try {
+              const parsed = JSON.parse(data);
+              if (parsed.model) modelName = parsed.model;
+              const usage = parsed.usage;
+              if (usage) {
+                inputTokens = usage.prompt_tokens ?? inputTokens;
+                outputTokens = usage.completion_tokens ?? outputTokens;
+              }
+              const delta = parsed.choices?.[0]?.delta?.content;
+              if (delta) {
+                accumulatedText += delta;
+                controller.enqueue(
+                  emit({
+                    type: "response.output_text.delta",
+                    item_id: ctx.itemId,
+                    output_index: messageOutputIndex,
+                    content_index: 0,
+                    delta,
+                  }),
+                );
+              }
+            } catch {
+              ctx.logger?.verbose("Flush: malformed SSE data in trailing buffer", {
+                data,
+              });
+            }
+          }
         }
-        const delta = parsed.choices?.[0]?.delta?.content;
-        if (delta) {
-          accumulatedText += delta;
-          controller.enqueue(
-            emit({
-              type: "response.output_text.delta",
-              item_id: ctx.itemId,
-              output_index: messageOutputIndex,
-              content_index: 0,
-              delta,
-            }),
-          );
-        }
-      } catch {
-        ctx.logger?.verbose("Flush: malformed SSE data in trailing buffer", {
-          data,
-        });
       }
+
+      if (!sentCreated) {
+        controller.enqueue(
+          emit({
+            type: "response.created",
+            response: {
+              id: ctx.responseId,
+              object: "response",
+              created_at: ctx.createdAt,
+              status: "in_progress",
+              model: modelName,
+            },
+          }),
+        );
+        sentCreated = true;
+      }
+
+      if (accumulatedText || sentContentPartAdded) {
+        controller.enqueue(
+          emit({
+            type: "response.output_text.done",
+            item_id: ctx.itemId,
+            output_index: messageOutputIndex,
+            content_index: 0,
+            text: accumulatedText,
+          }),
+        );
+        controller.enqueue(
+          emit({
+            type: "response.content_part.done",
+            item_id: ctx.itemId,
+            output_index: messageOutputIndex,
+            content_index: 0,
+            part: {
+              type: "output_text",
+              text: accumulatedText,
+              annotations: [],
+            },
+          }),
+        );
+        controller.enqueue(
+          emit({
+            type: "response.output_item.done",
+            output_index: messageOutputIndex,
+            item: {
+              id: ctx.itemId,
+              type: "message",
+              status: "completed",
+              role: "assistant",
+              content: [{ type: "output_text", text: accumulatedText }],
+            },
+          }),
+        );
+      }
+
+      for (const [, tcState] of toolCallStates) {
+        controller.enqueue(
+          emit({
+            type: "response.function_call_arguments.done",
+            item_id: tcState.id,
+            output_index: tcState.outputIndex,
+            arguments: tcState.arguments,
+          }),
+        );
+        controller.enqueue(
+          emit({
+            type: "response.output_item.done",
+            output_index: tcState.outputIndex,
+            item: {
+              id: tcState.id,
+              type: "function_call",
+              status: "completed",
+              name: tcState.name,
+              arguments: tcState.arguments,
+              call_id: tcState.id,
+            },
+          }),
+        );
+      }
+
+      controller.enqueue(
+        emit({
+          type: "response.completed",
+          response: {
+            id: ctx.responseId,
+            object: "response",
+            created_at: ctx.createdAt,
+            status: "completed",
+            model: modelName,
+            usage: {
+              input_tokens: inputTokens,
+              output_tokens: outputTokens,
+            },
+          },
+        }),
+      );
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
     },
   });
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,0 @@
-declare module "proper-lockfile";

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { accessTokenExpired } from "../src/plugin/auth";
+import { accessTokenExpired, isOAuthAuth } from "../src/plugin/auth";
+import type { AuthDetails } from "../src/plugin/types";
 
 const baseAuth = {
   type: "oauth" as const,
@@ -20,5 +21,36 @@ describe("accessTokenExpired", () => {
   it("uses buffer window", () => {
     const auth = { ...baseAuth, expires: Date.now() + 5_000 };
     expect(accessTokenExpired(auth, 10)).toBe(true);
+  });
+});
+
+describe("isOAuthAuth", () => {
+  it("accepts a normal refresh token", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "real-token",
+    };
+    expect(isOAuthAuth(auth)).toBe(true);
+  });
+
+  it("rejects the literal string undefined", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "undefined",
+    };
+    expect(isOAuthAuth(auth)).toBe(false);
+  });
+
+  it("rejects the literal string null", () => {
+    const auth: AuthDetails = {
+      type: "oauth",
+      refresh: "null",
+    };
+    expect(isOAuthAuth(auth)).toBe(false);
+  });
+
+  it("rejects empty refresh", () => {
+    const auth: AuthDetails = { type: "oauth", refresh: "" };
+    expect(isOAuthAuth(auth)).toBe(false);
   });
 });

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, mock } from "bun:test";
-import { refreshAccessToken } from "../src/plugin/token";
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { QwenTokenRefreshError, refreshAccessToken } from "../src/plugin/token";
 import type { OAuthAuthDetails, PluginClient } from "../src/plugin/types";
 
 const mockRefreshQwenToken = mock(() =>
@@ -15,6 +15,10 @@ const mockRefreshQwenToken = mock(() =>
 mock.module("../src/qwen/oauth", () => ({
   refreshQwenToken: mockRefreshQwenToken,
 }));
+
+afterEach(() => {
+  mockRefreshQwenToken.mockClear();
+});
 
 describe("refreshAccessToken", () => {
   it("persists updated auth details", async () => {
@@ -51,5 +55,28 @@ describe("refreshAccessToken", () => {
         resourceUrl: "https://resource.example",
       },
     });
+  });
+
+  it("does not call the token endpoint when refresh is the string undefined", async () => {
+    const auth = {
+      type: "oauth" as const,
+      refresh: "undefined",
+      access: "access-old",
+    } as OAuthAuthDetails;
+
+    const client = {
+      auth: { set: mock(() => Promise.resolve(undefined)) },
+    } as unknown as PluginClient;
+
+    await expect(
+      refreshAccessToken(
+        auth,
+        { clientId: "client", oauthBaseUrl: "https://chat.qwen.ai" },
+        client,
+        "qwen",
+      ),
+    ).rejects.toThrow(QwenTokenRefreshError);
+
+    expect(mockRefreshQwenToken).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: When Qwen's SSE stream terminates without sending `[DONE]` (connection drop, timeout, truncation), the `flush` handler returns early without emitting completion events (`response.output_text.done`, `response.completed`, `[DONE]`). This causes OpenCode to hang mid-response, appearing as a cutoff.

- **Fix**: 
  - Removed early returns in `flush` that silently swallowed termination events
  - Added `sentCompleted` guard flag to prevent duplicate events when `[DONE]` arrives normally through `transform`
  - `flush` now always emits the full completion sequence regardless of how the stream ended

- **Impact**: Responses no longer cut off mid-stream when Qwen's connection terminates uncleanly. OpenCode receives a proper `response.completed` event with whatever text was accumulated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where Qwen SSE streams that end without [DONE] caused OpenCode to hang mid-response. Flush now emits the full completion sequence even on unclean termination.

- **Bug Fixes**
  - Always emit completion events from flush: response.created (if missing), response.output_text.done, response.content_part.done, response.output_item.done, response.function_call_arguments.done, response.completed, and [DONE].
  - Added `sentCompleted` guard to prevent duplicate events when [DONE] arrives normally.
  - Removed early returns in flush and best-effort parse trailing buffer for model, usage, and last delta.

<sup>Written for commit 4f2b3d2bf1d03d1a1e3036ca5e8e955889ac5b2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

