### PR TITLE
feature(token): implemented new flow for store and get token

### DIFF
--- a/src/plugin/token.ts
+++ b/src/plugin/token.ts
@@ -1,5 +1,9 @@
-import { type QwenOAuthOptions, refreshQwenToken } from "../qwen/oauth";
+import { QwenAuthClient, type QwenOAuthOptions } from "../qwen/oauth";
 import { isValidOAuthRefreshToken } from "./auth";
+import {
+  SharedTokenManager,
+  TokenManagerError,
+} from "../qwen/sharedTokenManager";
 import type { OAuthAuthDetails, PluginClient } from "./types";
 
 export class QwenTokenRefreshError extends Error {
@@ -24,26 +28,42 @@ export async function refreshAccessToken(
       "invalid_request",
     );
   }
-  const result = await refreshQwenToken(options, auth.refresh);
 
-  if (result.type === "failed") {
-    throw new QwenTokenRefreshError(result.error, result.code);
-  }
-
-  const updated: OAuthAuthDetails = {
-    type: "oauth",
-    refresh: result.refresh,
-    access: result.access,
-    expires: result.expires,
-    resourceUrl: result.resourceUrl ?? auth.resourceUrl,
-  };
-
-  const body = updated as Parameters<PluginClient["auth"]["set"]>[0]["body"];
-
-  await client.auth.set({
-    path: { id: providerId },
-    body,
+  const authClient = new QwenAuthClient(options, {
+    access_token: auth.access || "",
+    refresh_token: auth.refresh as string,
+    token_type: "Bearer",
+    expiry_date: auth.expires,
+    resource_url: auth.resourceUrl,
   });
 
-  return updated;
+  const manager = SharedTokenManager.getInstance();
+
+  try {
+    const result = await manager.getValidCredentials(authClient, false); // forceRefresh=false because we only want to refresh if it's actually expired or missing
+
+    const updated: OAuthAuthDetails = {
+      type: "oauth",
+      refresh: result.refresh_token!,
+      access: result.access_token,
+      expires: result.expiry_date!,
+      resourceUrl: result.resource_url ?? auth.resourceUrl,
+    };
+
+    const body = updated as Parameters<PluginClient["auth"]["set"]>[0]["body"];
+
+    await client.auth.set({
+      path: { id: providerId },
+      body,
+    });
+
+    return updated;
+  } catch (error) {
+    if (error instanceof TokenManagerError) {
+      throw new QwenTokenRefreshError(error.message, error.type);
+    }
+    throw new QwenTokenRefreshError(
+      error instanceof Error ? error.message : "Failed to refresh token",
+    );
+  }
 }

--- a/src/qwen/oauth.ts
+++ b/src/qwen/oauth.ts
@@ -8,6 +8,12 @@ import {
 } from "../constants";
 import { calculateTokenExpiry, isValidOAuthRefreshToken } from "../plugin/auth";
 import { createLogger } from "../plugin/logger";
+import type {
+  ErrorData,
+  QwenCredentials,
+  QwenTokenClient,
+  TokenRefreshData,
+} from "./sharedTokenManager";
 
 const logger = createLogger("oauth");
 
@@ -268,4 +274,58 @@ export async function refreshQwenToken(
     expires: calculateTokenExpiry(Date.now(), payload.expires_in),
     resourceUrl: payload.resource_url,
   };
+}
+
+export class QwenAuthClient implements QwenTokenClient {
+  private options: QwenOAuthOptions;
+  private credentials: QwenCredentials;
+
+  constructor(options: QwenOAuthOptions, credentials: QwenCredentials) {
+    this.options = options;
+    this.credentials = credentials;
+  }
+
+  getCredentials(): QwenCredentials {
+    return this.credentials;
+  }
+
+  setCredentials(credentials: QwenCredentials): void {
+    this.credentials = credentials;
+  }
+
+  async refreshAccessToken(): Promise<TokenRefreshData | ErrorData> {
+    if (!this.credentials.refresh_token) {
+      return {
+        error: "invalid_request",
+        error_description: "No refresh token available",
+      };
+    }
+
+    const result = await refreshQwenToken(
+      this.options,
+      this.credentials.refresh_token,
+    );
+
+    if (result.type === "failed") {
+      return {
+        error: result.code ?? "refresh_failed",
+        error_description: result.error,
+      };
+    }
+
+    // Convert absolute expires (ms) back to relative expires_in (seconds)
+    // using the same logic calculateTokenExpiry uses to create it
+    const expiresInSeconds = Math.max(
+      0,
+      Math.floor((result.expires - Date.now()) / 1000),
+    );
+
+    return {
+      access_token: result.access,
+      refresh_token: result.refresh,
+      token_type: "Bearer",
+      expires_in: expiresInSeconds,
+      resource_url: result.resourceUrl,
+    };
+  }
 }

--- a/src/qwen/sharedTokenManager.ts
+++ b/src/qwen/sharedTokenManager.ts
@@ -1,0 +1,695 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'node:path';
+import { promises as fs, unlinkSync } from 'node:fs';
+import * as os from 'os';
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '../plugin/logger.js';
+
+const debugLogger = createLogger('SharedTokenManager');
+
+export interface QwenCredentials {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expiry_date?: number;
+  resource_url?: string;
+}
+
+export interface TokenRefreshData {
+  access_token: string;
+  refresh_token?: string;
+  token_type: string;
+  expires_in: number;
+  resource_url?: string;
+}
+
+export interface ErrorData {
+  error: string;
+  error_description?: string;
+}
+
+export function isErrorResponse(response: unknown): response is ErrorData {
+  return typeof response === 'object' && response !== null && 'error' in response;
+}
+
+export class CredentialsClearRequiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CredentialsClearRequiredError';
+  }
+}
+
+export interface QwenTokenClient {
+  getCredentials(): QwenCredentials;
+  setCredentials(credentials: QwenCredentials): void;
+  refreshAccessToken(): Promise<TokenRefreshData | ErrorData>;
+}
+
+// File System Configuration
+const QWEN_DIR = '.qwen';
+const QWEN_CREDENTIAL_FILENAME = 'oauth_creds.json';
+const QWEN_LOCK_FILENAME = 'oauth_creds.lock';
+
+// Token and Cache Configuration
+const TOKEN_REFRESH_BUFFER_MS = 30 * 1000; // 30 seconds
+const LOCK_TIMEOUT_MS = 10000; // 10 seconds lock timeout
+const CACHE_CHECK_INTERVAL_MS = 5000; // 5 seconds cache check interval
+
+interface LockConfig {
+  maxAttempts: number;
+  attemptInterval: number;
+  maxInterval: number;
+}
+
+const DEFAULT_LOCK_CONFIG: LockConfig = {
+  maxAttempts: 20,
+  attemptInterval: 100,
+  maxInterval: 2000,
+};
+
+export enum TokenError {
+  REFRESH_FAILED = 'REFRESH_FAILED',
+  NO_REFRESH_TOKEN = 'NO_REFRESH_TOKEN',
+  LOCK_TIMEOUT = 'LOCK_TIMEOUT',
+  FILE_ACCESS_ERROR = 'FILE_ACCESS_ERROR',
+  NETWORK_ERROR = 'NETWORK_ERROR',
+}
+
+export class TokenManagerError extends Error {
+  constructor(
+    public type: TokenError,
+    message: string,
+    public originalError?: unknown,
+  ) {
+    super(message);
+    this.name = 'TokenManagerError';
+  }
+}
+
+interface MemoryCache {
+  credentials: QwenCredentials | null;
+  fileModTime: number;
+  lastCheck: number;
+}
+
+function validateCredentials(data: unknown): QwenCredentials {
+  if (!data || typeof data !== 'object') {
+    throw new Error('Invalid credentials format');
+  }
+
+  const creds = data as Partial<QwenCredentials>;
+  const requiredFields = ['access_token', 'refresh_token', 'token_type'] as const;
+
+  for (const field of requiredFields) {
+    if (!creds[field] || typeof creds[field] !== 'string') {
+      throw new Error(`Invalid credentials: missing ${field}`);
+    }
+  }
+
+  if (!creds.expiry_date || typeof creds.expiry_date !== 'number') {
+    throw new Error('Invalid credentials: missing expiry_date');
+  }
+
+  return creds as QwenCredentials;
+}
+
+export class SharedTokenManager {
+  private static instance: SharedTokenManager | null = null;
+
+  private memoryCache: MemoryCache = {
+    credentials: null,
+    fileModTime: 0,
+    lastCheck: 0,
+  };
+
+  private refreshPromise: Promise<QwenCredentials> | null = null;
+  private checkPromise: Promise<void> | null = null;
+  private cleanupHandlersRegistered = false;
+  private cleanupFunction: (() => void) | null = null;
+  private lockConfig: LockConfig = DEFAULT_LOCK_CONFIG;
+
+  private constructor() {
+    this.registerCleanupHandlers();
+  }
+
+  static getInstance(): SharedTokenManager {
+    if (!SharedTokenManager.instance) {
+      SharedTokenManager.instance = new SharedTokenManager();
+    }
+    return SharedTokenManager.instance;
+  }
+
+  private registerCleanupHandlers(): void {
+    if (this.cleanupHandlersRegistered) {
+      return;
+    }
+
+    this.cleanupFunction = () => {
+      try {
+        const lockPath = this.getLockFilePath();
+        unlinkSync(lockPath);
+      } catch (_error) {
+      }
+    };
+
+    process.on('exit', this.cleanupFunction);
+    process.on('SIGINT', this.cleanupFunction);
+    process.on('SIGTERM', this.cleanupFunction);
+    process.on('uncaughtException', this.cleanupFunction);
+    process.on('unhandledRejection', this.cleanupFunction);
+
+    this.cleanupHandlersRegistered = true;
+  }
+
+  async getValidCredentials(
+    qwenClient: QwenTokenClient,
+    forceRefresh = false,
+  ): Promise<QwenCredentials> {
+    try {
+      await this.checkAndReloadIfNeeded(qwenClient);
+
+      if (
+        !forceRefresh &&
+        this.memoryCache.credentials &&
+        this.isTokenValid(this.memoryCache.credentials)
+      ) {
+        return this.memoryCache.credentials;
+      }
+
+      let currentRefreshPromise = this.refreshPromise;
+
+      if (!currentRefreshPromise) {
+        currentRefreshPromise = this.performTokenRefresh(
+          qwenClient,
+          forceRefresh,
+        );
+        this.refreshPromise = currentRefreshPromise;
+      }
+
+      try {
+        const result = await currentRefreshPromise;
+        return result;
+      } finally {
+        if (this.refreshPromise === currentRefreshPromise) {
+          this.refreshPromise = null;
+        }
+      }
+    } catch (error) {
+      if (error instanceof TokenManagerError) {
+        throw error;
+      }
+
+      throw new TokenManagerError(
+        TokenError.REFRESH_FAILED,
+        `Failed to get valid credentials: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+    }
+  }
+
+  private async checkAndReloadIfNeeded(
+    qwenClient?: QwenTokenClient,
+  ): Promise<void> {
+    if (this.checkPromise) {
+      await this.checkPromise;
+      return;
+    }
+
+    if (this.refreshPromise) {
+      return;
+    }
+
+    const now = Date.now();
+
+    if (now - this.memoryCache.lastCheck < CACHE_CHECK_INTERVAL_MS) {
+      return;
+    }
+
+    this.checkPromise = this.performFileCheck(qwenClient, now);
+
+    try {
+      await this.checkPromise;
+    } finally {
+      this.checkPromise = null;
+    }
+  }
+
+  private withTimeout<T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    operationType = 'Operation',
+  ): Promise<T> {
+    let timeoutId: NodeJS.Timeout;
+
+    return Promise.race([
+      promise.finally(() => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      }),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () =>
+            reject(
+              new Error(`${operationType} timed out after ${timeoutMs}ms`),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  }
+
+  private async performFileCheck(
+    qwenClient: QwenTokenClient | undefined,
+    checkTime: number,
+  ): Promise<void> {
+    this.memoryCache.lastCheck = checkTime;
+
+    try {
+      const filePath = this.getCredentialFilePath();
+
+      const stats = await this.withTimeout(
+        fs.stat(filePath),
+        3000,
+        'File operation',
+      );
+      const fileModTime = stats.mtimeMs;
+
+      if (fileModTime > this.memoryCache.fileModTime) {
+        await this.reloadCredentialsFromFile(qwenClient);
+        this.memoryCache.fileModTime = fileModTime;
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as NodeJS.ErrnoException).code !== 'ENOENT'
+      ) {
+        this.updateCacheState(null, 0, checkTime);
+
+        throw new TokenManagerError(
+          TokenError.FILE_ACCESS_ERROR,
+          `Failed to access credentials file: ${error.message}`,
+          error,
+        );
+      }
+
+      this.memoryCache.fileModTime = 0;
+    }
+  }
+
+  private async forceFileCheck(qwenClient?: QwenTokenClient): Promise<void> {
+    try {
+      const filePath = this.getCredentialFilePath();
+      const stats = await fs.stat(filePath);
+      const fileModTime = stats.mtimeMs;
+
+      if (fileModTime > this.memoryCache.fileModTime) {
+        await this.reloadCredentialsFromFile(qwenClient);
+        this.memoryCache.fileModTime = fileModTime;
+        this.memoryCache.lastCheck = Date.now();
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        (error as NodeJS.ErrnoException).code !== 'ENOENT'
+      ) {
+        this.updateCacheState(null, 0);
+
+        throw new TokenManagerError(
+          TokenError.FILE_ACCESS_ERROR,
+          `Failed to access credentials file during refresh: ${error.message}`,
+          error,
+        );
+      }
+
+      this.memoryCache.fileModTime = 0;
+    }
+  }
+
+  private async reloadCredentialsFromFile(
+    qwenClient?: QwenTokenClient,
+  ): Promise<void> {
+    try {
+      const filePath = this.getCredentialFilePath();
+      const content = await fs.readFile(filePath, 'utf-8');
+      const parsedData = JSON.parse(content);
+      const credentials = validateCredentials(parsedData);
+
+      const previousCredentials = this.memoryCache.credentials;
+
+      this.memoryCache.credentials = credentials;
+
+      try {
+        if (qwenClient) {
+          qwenClient.setCredentials(credentials);
+        }
+      } catch (clientError) {
+        this.memoryCache.credentials = previousCredentials;
+        throw clientError;
+      }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Invalid credentials')
+      ) {
+        debugLogger.warn(
+          `Failed to validate credentials file: ${error.message}`,
+        );
+      }
+      this.memoryCache.credentials = null;
+    }
+  }
+
+  private async performTokenRefresh(
+    qwenClient: QwenTokenClient,
+    forceRefresh = false,
+  ): Promise<QwenCredentials> {
+    const startTime = Date.now();
+    const lockPath = this.getLockFilePath();
+    let lockAcquired = false;
+
+    try {
+      const currentCredentials = qwenClient.getCredentials();
+      if (!currentCredentials.refresh_token) {
+        throw new TokenManagerError(
+          TokenError.NO_REFRESH_TOKEN,
+          'No refresh token available for token refresh',
+        );
+      }
+
+      await this.acquireLock(lockPath);
+      lockAcquired = true;
+
+      const lockAcquisitionTime = Date.now() - startTime;
+      if (lockAcquisitionTime > 5000) {
+        debugLogger.warn(
+          `Token refresh lock acquisition took ${lockAcquisitionTime}ms`,
+        );
+      }
+
+      await this.forceFileCheck(qwenClient);
+
+      if (
+        !forceRefresh &&
+        this.memoryCache.credentials &&
+        this.isTokenValid(this.memoryCache.credentials)
+      ) {
+        return this.memoryCache.credentials;
+      }
+
+      const response = await qwenClient.refreshAccessToken();
+
+      const totalOperationTime = Date.now() - startTime;
+      if (totalOperationTime > 10000) {
+        debugLogger.warn(
+          `Token refresh operation took ${totalOperationTime}ms`,
+        );
+      }
+
+      if (!response || isErrorResponse(response)) {
+        const errorData = response as ErrorData;
+        throw new TokenManagerError(
+          TokenError.REFRESH_FAILED,
+          `Token refresh failed: ${errorData?.error || 'Unknown error'} - ${errorData?.error_description || 'No details provided'}`,
+        );
+      }
+
+      const tokenData = response as TokenRefreshData;
+
+      if (!tokenData.access_token) {
+        throw new TokenManagerError(
+          TokenError.REFRESH_FAILED,
+          'Failed to refresh access token: no token returned',
+        );
+      }
+
+      const credentials: QwenCredentials = {
+        access_token: tokenData.access_token,
+        token_type: tokenData.token_type,
+        refresh_token:
+          tokenData.refresh_token || currentCredentials.refresh_token,
+        resource_url: tokenData.resource_url,
+        expiry_date: Date.now() + tokenData.expires_in * 1000,
+      };
+
+      this.memoryCache.credentials = credentials;
+      qwenClient.setCredentials(credentials);
+
+      await this.saveCredentialsToFile(credentials);
+
+      return credentials;
+    } catch (error) {
+      if (error instanceof CredentialsClearRequiredError) {
+        debugLogger.debug(
+          'SharedTokenManager: Clearing memory cache due to credentials clear requirement',
+        );
+        this.memoryCache.credentials = null;
+        this.memoryCache.fileModTime = 0;
+        this.refreshPromise = null;
+
+        throw new TokenManagerError(
+          TokenError.REFRESH_FAILED,
+          error.message,
+          error,
+        );
+      }
+
+      if (error instanceof TokenManagerError) {
+        throw error;
+      }
+
+      if (
+        error instanceof Error &&
+        (error.message.includes('fetch') ||
+          error.message.includes('network') ||
+          error.message.includes('timeout'))
+      ) {
+        throw new TokenManagerError(
+          TokenError.NETWORK_ERROR,
+          `Network error during token refresh: ${error.message}`,
+          error,
+        );
+      }
+
+      throw new TokenManagerError(
+        TokenError.REFRESH_FAILED,
+        `Unexpected error during token refresh: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+    } finally {
+      if (lockAcquired) {
+        await this.releaseLock(lockPath);
+      }
+    }
+  }
+
+  private async saveCredentialsToFile(
+    credentials: QwenCredentials,
+  ): Promise<void> {
+    const filePath = this.getCredentialFilePath();
+    const dirPath = path.dirname(filePath);
+    const tempPath = `${filePath}.tmp.${randomUUID()}`;
+
+    try {
+      await this.withTimeout(
+        fs.mkdir(dirPath, { recursive: true, mode: 0o700 }),
+        5000,
+        'File operation',
+      );
+    } catch (error) {
+      throw new TokenManagerError(
+        TokenError.FILE_ACCESS_ERROR,
+        `Failed to create credentials directory: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+    }
+
+    const credString = JSON.stringify(credentials, null, 2);
+
+    try {
+      await this.withTimeout(
+        fs.writeFile(tempPath, credString, { mode: 0o600 }),
+        5000,
+        'File operation',
+      );
+
+      await this.withTimeout(
+        fs.rename(tempPath, filePath),
+        5000,
+        'File operation',
+      );
+
+      const stats = await this.withTimeout(
+        fs.stat(filePath),
+        5000,
+        'File operation',
+      );
+      this.memoryCache.fileModTime = stats.mtimeMs;
+    } catch (error) {
+      try {
+        await this.withTimeout(fs.unlink(tempPath), 1000, 'File operation');
+      } catch (_cleanupError) {
+      }
+
+      throw new TokenManagerError(
+        TokenError.FILE_ACCESS_ERROR,
+        `Failed to write credentials file: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      );
+    }
+  }
+
+  private isTokenValid(credentials: QwenCredentials): boolean {
+    if (!credentials.expiry_date || !credentials.access_token) {
+      return false;
+    }
+    return Date.now() < credentials.expiry_date - TOKEN_REFRESH_BUFFER_MS;
+  }
+
+  private getCredentialFilePath(): string {
+    return path.join(os.homedir(), QWEN_DIR, QWEN_CREDENTIAL_FILENAME);
+  }
+
+  private getLockFilePath(): string {
+    return path.join(os.homedir(), QWEN_DIR, QWEN_LOCK_FILENAME);
+  }
+
+  private async acquireLock(lockPath: string): Promise<void> {
+    const { maxAttempts, attemptInterval, maxInterval } = this.lockConfig;
+    const lockId = randomUUID();
+
+    let currentInterval = attemptInterval;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        await fs.mkdir(path.dirname(lockPath), { recursive: true }).catch(() => {});
+        await fs.writeFile(lockPath, lockId, { flag: 'wx' });
+        return;
+      } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          try {
+            const stats = await fs.stat(lockPath);
+            const lockAge = Date.now() - stats.mtimeMs;
+
+            if (lockAge > LOCK_TIMEOUT_MS) {
+              const tempPath = `${lockPath}.stale.${randomUUID()}`;
+              try {
+                await fs.rename(lockPath, tempPath);
+                await fs.unlink(tempPath);
+                debugLogger.warn(
+                  `Removed stale lock file: ${lockPath} (age: ${lockAge}ms)`,
+                );
+                continue;
+              } catch (renameError) {
+                debugLogger.warn(
+                  `Failed to remove stale lock file ${lockPath}: ${renameError instanceof Error ? renameError.message : String(renameError)}`,
+                );
+              }
+            }
+          } catch (statError) {
+            debugLogger.warn(
+              `Failed to stat lock file ${lockPath}: ${statError instanceof Error ? statError.message : String(statError)}`,
+            );
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, currentInterval));
+          currentInterval = Math.min(currentInterval * 1.5, maxInterval);
+        } else {
+          throw new TokenManagerError(
+            TokenError.FILE_ACCESS_ERROR,
+            `Failed to create lock file: ${error instanceof Error ? error.message : String(error)}`,
+            error,
+          );
+        }
+      }
+    }
+
+    throw new TokenManagerError(
+      TokenError.LOCK_TIMEOUT,
+      'Failed to acquire file lock for token refresh: timeout exceeded',
+    );
+  }
+
+  private async releaseLock(lockPath: string): Promise<void> {
+    try {
+      await fs.unlink(lockPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        debugLogger.warn(
+          `Failed to release lock file ${lockPath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  private updateCacheState(
+    credentials: QwenCredentials | null,
+    fileModTime: number,
+    lastCheck?: number,
+  ): void {
+    this.memoryCache = {
+      credentials,
+      fileModTime,
+      lastCheck: lastCheck ?? Date.now(),
+    };
+  }
+
+  clearCache(): void {
+    this.updateCacheState(null, 0, 0);
+    this.refreshPromise = null;
+    this.checkPromise = null;
+  }
+
+  getCurrentCredentials(): QwenCredentials | null {
+    return this.memoryCache.credentials;
+  }
+
+  isRefreshInProgress(): boolean {
+    return this.refreshPromise !== null;
+  }
+
+  setLockConfig(config: Partial<LockConfig>): void {
+    this.lockConfig = { ...DEFAULT_LOCK_CONFIG, ...config };
+  }
+
+  cleanup(): void {
+    if (this.cleanupFunction && this.cleanupHandlersRegistered) {
+      this.cleanupFunction();
+
+      process.removeListener('exit', this.cleanupFunction);
+      process.removeListener('SIGINT', this.cleanupFunction);
+      process.removeListener('SIGTERM', this.cleanupFunction);
+      process.removeListener('uncaughtException', this.cleanupFunction);
+      process.removeListener('unhandledRejection', this.cleanupFunction);
+
+      this.cleanupHandlersRegistered = false;
+      this.cleanupFunction = null;
+    }
+  }
+
+  getDebugInfo(): {
+    hasCredentials: boolean;
+    credentialsExpired: boolean;
+    isRefreshing: boolean;
+    cacheAge: number;
+  } {
+    const hasCredentials = !!this.memoryCache.credentials;
+    const credentialsExpired = hasCredentials
+      ? !this.isTokenValid(this.memoryCache.credentials!)
+      : false;
+
+    return {
+      hasCredentials,
+      credentialsExpired,
+      isRefreshing: this.isRefreshInProgress(),
+      cacheAge: Date.now() - this.memoryCache.lastCheck,
+    };
+  }
+}

--- a/test/oauth.test.ts
+++ b/test/oauth.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { QwenAuthClient } from "../src/qwen/oauth";
+import type { QwenCredentials } from "../src/qwen/sharedTokenManager";
+
+describe("QwenAuthClient", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should initialize with credentials and return them", () => {
+    const creds: QwenCredentials = {
+      access_token: "access1",
+      refresh_token: "refresh1",
+      token_type: "Bearer",
+      expiry_date: 1000000,
+    };
+    const client = new QwenAuthClient(
+      { clientId: "test", oauthBaseUrl: "http://test" },
+      creds,
+    );
+
+    expect(client.getCredentials()).toEqual(creds);
+  });
+
+  it("should update credentials", () => {
+    const creds1: QwenCredentials = {
+      access_token: "access1",
+      refresh_token: "refresh1",
+      token_type: "Bearer",
+    };
+    const creds2: QwenCredentials = {
+      access_token: "access2",
+      refresh_token: "refresh2",
+      token_type: "Bearer",
+    };
+    const client = new QwenAuthClient(
+      { clientId: "test", oauthBaseUrl: "http://test" },
+      creds1,
+    );
+
+    client.setCredentials(creds2);
+    expect(client.getCredentials()).toEqual(creds2);
+  });
+
+  it("should refresh access token and map success response", async () => {
+    const creds: QwenCredentials = {
+      access_token: "old-access",
+      refresh_token: "valid-refresh-token",
+      token_type: "Bearer",
+    };
+    const client = new QwenAuthClient(
+      { clientId: "test", oauthBaseUrl: "http://test" },
+      creds,
+    );
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+      }),
+    };
+    global.fetch = mock(async () => mockResponse as unknown as Response) as any;
+
+    const result = await client.refreshAccessToken();
+
+    // Check if result matches TokenRefreshData shape
+    expect(result).not.toHaveProperty("error");
+    if ("access_token" in result) {
+      expect(result.access_token).toBe("new-access");
+      expect(result.refresh_token).toBe("new-refresh");
+      // calculateTokenExpiry computes expiry as Date.now() + expires_in * 1000
+      // SharedTokenManager expects expires_in in seconds.
+      expect(result.expires_in).toBeGreaterThan(0);
+      // Wait, QwenAuthClient will return something where expires_in is roughly 3600.
+      expect(result.expires_in).toBeGreaterThanOrEqual(3590);
+      expect(result.expires_in).toBeLessThanOrEqual(3610);
+      expect(result.token_type).toBe("Bearer");
+    } else {
+      throw new Error("Expected TokenRefreshData, got ErrorData");
+    }
+  });
+
+  it("should handle refresh failure and map error response", async () => {
+    const creds: QwenCredentials = {
+      access_token: "old-access",
+      refresh_token: "bad-refresh",
+      token_type: "Bearer",
+    };
+    const client = new QwenAuthClient(
+      { clientId: "test", oauthBaseUrl: "http://test" },
+      creds,
+    );
+
+    const mockResponse = {
+      ok: false,
+      text: async () =>
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Invalid refresh token",
+        }),
+    };
+    global.fetch = mock(async () => mockResponse as unknown as Response) as any;
+
+    const result = await client.refreshAccessToken();
+
+    expect(result).toHaveProperty("error");
+    if ("error" in result) {
+      expect(result.error).toBe("invalid_grant");
+      expect(result.error_description).toBe("Invalid refresh token");
+    } else {
+      throw new Error("Expected ErrorData");
+    }
+  });
+
+  it("should return error if no refresh token exists", async () => {
+    const creds: QwenCredentials = {
+      access_token: "old-access",
+      token_type: "Bearer",
+      // no refresh_token
+    };
+    const client = new QwenAuthClient(
+      { clientId: "test", oauthBaseUrl: "http://test" },
+      creds,
+    );
+
+    const result = await client.refreshAccessToken();
+
+    expect(result).toHaveProperty("error");
+    if ("error" in result) {
+      expect(result.error).toBe("invalid_request");
+    } else {
+      throw new Error("Expected ErrorData");
+    }
+  });
+});

--- a/test/sharedTokenManager.test.ts
+++ b/test/sharedTokenManager.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+import { SharedTokenManager, TokenError, TokenManagerError, type QwenTokenClient, type QwenCredentials, type TokenRefreshData } from "../src/qwen/sharedTokenManager.ts";
+import { promises as fs } from "node:fs";
+import * as os from "os";
+import path from "node:path";
+
+describe("SharedTokenManager", () => {
+  let manager: SharedTokenManager;
+  let tempDir: string;
+  let mockClient: QwenTokenClient;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'qwen-test-'));
+    spyOn(os, "homedir").mockReturnValue(tempDir);
+    
+    // @ts-ignore
+    SharedTokenManager.instance = null;
+    manager = SharedTokenManager.getInstance();
+    manager.setLockConfig({ maxAttempts: 5, attemptInterval: 10, maxInterval: 50 }); // fast lock config
+    
+    let currentCreds: QwenCredentials = {
+      access_token: "init_access",
+      refresh_token: "init_refresh",
+      token_type: "Bearer",
+      expiry_date: Date.now() - 1000 // expired
+    };
+    
+    mockClient = {
+      getCredentials: () => currentCreds,
+      setCredentials: (creds) => { currentCreds = creds; },
+      refreshAccessToken: async () => ({
+        access_token: "new_access",
+        refresh_token: "new_refresh",
+        token_type: "Bearer",
+        expires_in: 3600
+      })
+    };
+  });
+
+  afterEach(async () => {
+    manager.cleanup();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("should be a singleton", () => {
+    const instance1 = SharedTokenManager.getInstance();
+    const instance2 = SharedTokenManager.getInstance();
+    expect(instance1).toBe(instance2);
+  });
+
+  test("should return valid cached credentials without refresh", async () => {
+    const validCreds: QwenCredentials = {
+      access_token: "valid_access",
+      refresh_token: "valid_refresh",
+      token_type: "Bearer",
+      expiry_date: Date.now() + 60000 // valid for 1 min
+    };
+    
+    mockClient.setCredentials(validCreds);
+    // Directly setting memory cache for testing
+    // @ts-ignore
+    manager.memoryCache.credentials = validCreds;
+    
+    const creds = await manager.getValidCredentials(mockClient, false);
+    expect(creds.access_token).toBe("valid_access");
+  });
+
+  test("should refresh credentials if expired", async () => {
+    const creds = await manager.getValidCredentials(mockClient, false);
+    expect(creds.access_token).toBe("new_access");
+    expect(creds.refresh_token).toBe("new_refresh");
+  });
+
+  test("should handle concurrent refreshes safely", async () => {
+    let refreshCount = 0;
+    
+    const slowMockClient: QwenTokenClient = {
+      ...mockClient,
+      refreshAccessToken: async () => {
+        refreshCount++;
+        await new Promise(r => setTimeout(r, 50));
+        return {
+          access_token: "concurrent_access",
+          refresh_token: "concurrent_refresh",
+          token_type: "Bearer",
+          expires_in: 3600
+        };
+      }
+    };
+
+    const p1 = manager.getValidCredentials(slowMockClient, false);
+    const p2 = manager.getValidCredentials(slowMockClient, false);
+    
+    const [res1, res2] = await Promise.all([p1, p2]);
+    expect(res1.access_token).toBe("concurrent_access");
+    expect(res2.access_token).toBe("concurrent_access");
+    
+    // Only 1 actual API refresh call should be made because of promise reuse
+    expect(refreshCount).toBe(1);
+  });
+
+  test("should throw NO_REFRESH_TOKEN if missing", async () => {
+    const badClient: QwenTokenClient = {
+      getCredentials: () => ({ access_token: "a", token_type: "b", expiry_date: Date.now() - 1000 }),
+      setCredentials: () => {},
+      refreshAccessToken: async () => ({ access_token: "new", token_type: "b", expires_in: 1 })
+    };
+    
+    await expect(manager.getValidCredentials(badClient, false))
+      .rejects.toThrow(/No refresh token available/);
+  });
+});

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,23 +1,41 @@
-import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 import { QwenTokenRefreshError, refreshAccessToken } from "../src/plugin/token";
 import type { OAuthAuthDetails, PluginClient } from "../src/plugin/types";
+import {
+  SharedTokenManager,
+  TokenManagerError,
+  TokenError,
+} from "../src/qwen/sharedTokenManager";
 
-const mockRefreshQwenToken = mock(() =>
+const mockGetValidCredentials = mock(() =>
   Promise.resolve({
-    type: "success" as const,
-    access: "access-new",
-    refresh: "refresh-new",
-    expires: 123456,
-    resourceUrl: "https://resource.example",
+    access_token: "access-new",
+    refresh_token: "refresh-new",
+    token_type: "Bearer",
+    expiry_date: 123456,
+    resource_url: "https://resource.example",
   }),
 );
 
-mock.module("../src/qwen/oauth", () => ({
-  refreshQwenToken: mockRefreshQwenToken,
-}));
+let getInstanceSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  getInstanceSpy = spyOn(SharedTokenManager, "getInstance").mockReturnValue({
+    getValidCredentials: mockGetValidCredentials,
+  } as unknown as SharedTokenManager);
+});
 
 afterEach(() => {
-  mockRefreshQwenToken.mockClear();
+  getInstanceSpy.mockRestore();
+  mockGetValidCredentials.mockClear();
 });
 
 describe("refreshAccessToken", () => {
@@ -77,6 +95,75 @@ describe("refreshAccessToken", () => {
       ),
     ).rejects.toThrow(QwenTokenRefreshError);
 
-    expect(mockRefreshQwenToken).not.toHaveBeenCalled();
+    expect(mockGetValidCredentials).not.toHaveBeenCalled();
+  });
+
+  it("throws QwenTokenRefreshError with specific code when TokenManagerError is thrown", async () => {
+    const auth: OAuthAuthDetails = {
+      type: "oauth",
+      refresh: "refresh-old",
+      access: "access-old",
+      expires: 1000,
+    };
+    const client = { auth: { set: mock() } } as unknown as PluginClient;
+
+    mockGetValidCredentials.mockRejectedValueOnce(
+      new TokenManagerError(
+        TokenError.REFRESH_FAILED,
+        "Custom token manager error",
+      ),
+    );
+
+    let caughtError: Error | undefined;
+    try {
+      await refreshAccessToken(
+        auth,
+        { clientId: "client", oauthBaseUrl: "https://chat.qwen.ai" },
+        client,
+        "qwen",
+      );
+    } catch (e: any) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBeInstanceOf(QwenTokenRefreshError);
+    expect((caughtError as QwenTokenRefreshError).message).toBe(
+      "Custom token manager error",
+    );
+    expect((caughtError as QwenTokenRefreshError).code).toBe(
+      TokenError.REFRESH_FAILED,
+    );
+  });
+
+  it("throws generic QwenTokenRefreshError when an unknown Error is thrown", async () => {
+    const auth: OAuthAuthDetails = {
+      type: "oauth",
+      refresh: "refresh-old",
+      access: "access-old",
+      expires: 1000,
+    };
+    const client = { auth: { set: mock() } } as unknown as PluginClient;
+
+    mockGetValidCredentials.mockRejectedValueOnce(
+      new Error("Generic network error"),
+    );
+
+    let caughtError: Error | undefined;
+    try {
+      await refreshAccessToken(
+        auth,
+        { clientId: "client", oauthBaseUrl: "https://chat.qwen.ai" },
+        client,
+        "qwen",
+      );
+    } catch (e: any) {
+      caughtError = e;
+    }
+
+    expect(caughtError).toBeInstanceOf(QwenTokenRefreshError);
+    expect((caughtError as QwenTokenRefreshError).message).toBe(
+      "Generic network error",
+    );
+    expect((caughtError as QwenTokenRefreshError).code).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
This PR implemented new flow for store and get token. This PR will be use default token file from qwen code instead create another token file.

## Type of Change
- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [X] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🔧 Config/CI

## Self-Review Checklist
- [X] Code compiles and tests pass (`bun test`)
- [X] Lint passes (`bun run lint`)
- [X] Build succeeds (`bun run build`)
- [X] Changes are covered by tests (if applicable)
- [X] README/AGENTS.md updated (if applicable)
- [X] No hardcoded secrets or credentials
- [X] Commit messages are clear and descriptive

## Related Issues
<!-- Use "Closes #123" to auto-close issues -->
Closes #17 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched token refresh to a shared, file-backed manager that uses Qwen’s default token file, fixing flaky refreshes and preventing concurrent refresh races.

- **Bug Fixes**
  - Replaced direct refresh calls with `SharedTokenManager` to cache tokens, lock file writes, and reuse in-memory state across calls.
  - Added `QwenAuthClient` to adapt existing refresh logic to the shared manager.
  - Improved error mapping with `TokenManagerError` and `QwenTokenRefreshError`.
  - Added tests for the new manager and OAuth client; updated token tests.

- **Migration**
  - Tokens now read/write to ~/.qwen/oauth_creds.json (and lock file). Ensure write access to the home directory.
  - Remove any custom token file usage; the app now relies on the default Qwen token file location.

<sup>Written for commit c3b326d453e0ce67637629982f50626812a18e53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

